### PR TITLE
Rename tsallis to entmax

### DIFF
--- a/entmax/activations.py
+++ b/entmax/activations.py
@@ -9,9 +9,10 @@ By Ben Peters and Vlad Niculae
 """
 
 import torch
+import torch.nn as nn
 from torch.autograd import Function
 import torch.nn as nn
-from entmax.root_finding import tsallis_bisect, sparsemax_bisect
+from entmax.root_finding import entmax_bisect, sparsemax_bisect
 
 
 def _make_ix_like(input, dim=0):
@@ -190,7 +191,7 @@ class LogSparsemaxTopK(nn.Module):
         return torch.log(sparsemax_topk(input, self.dim, self.k))
 
 
-def _tsallis_threshold_and_support(input, dim=0):
+def _entmax_threshold_and_support(input, dim=0):
     Xsrt, _ = torch.sort(input, descending=True, dim=dim)
 
     rho = _make_ix_like(input, dim)
@@ -210,7 +211,7 @@ def _tsallis_threshold_and_support(input, dim=0):
     return tau_star, support_size
 
 
-def _tsallis_threshold_and_support_topk(input, dim=0, k=100):
+def _entmax_threshold_and_support_topk(input, dim=0, k=100):
 
     if k >= input.shape[dim]:  # do full sort
         Xsrt, _ = torch.sort(input, dim=dim, descending=True)
@@ -236,23 +237,23 @@ def _tsallis_threshold_and_support_topk(input, dim=0, k=100):
 
     if torch.any(unsolved):
         X_ = _roll_last(input, dim)[unsolved]
-        tau_, ss_ = _tsallis_threshold_and_support_topk(X_, dim=-1, k=2 * k)
+        tau_, ss_ = _entmax_threshold_and_support_topk(X_, dim=-1, k=2 * k)
         _roll_last(tau_star, dim)[unsolved] = tau_
         _roll_last(support_size, dim)[unsolved] = ss_
 
     return tau_star, support_size
 
 
-class Tsallis15Function(Function):
+class Entmax15Function(Function):
     @staticmethod
     def forward(ctx, X, dim=0):
         ctx.dim = dim
 
         max_val, _ = X.max(dim=dim, keepdim=True)
         X = X - max_val  # same numerical stability trick as for softmax
-        X = X / 2  # divide by 2 to solve actual Tsallis
+        X = X / 2  # divide by 2 to solve actual Entmax
 
-        tau_star, _ = _tsallis_threshold_and_support(X, dim)
+        tau_star, _ = _entmax_threshold_and_support(X, dim)
 
         Y = torch.clamp(X - tau_star, min=0) ** 2
         ctx.save_for_backward(Y)
@@ -269,16 +270,16 @@ class Tsallis15Function(Function):
         return dX, None
 
 
-class Tsallis15TopKFunction(Tsallis15Function):
+class Entmax15TopKFunction(Entmax15Function):
     @staticmethod
     def forward(ctx, X, dim=0, k=100):
         ctx.dim = dim
 
         max_val, _ = X.max(dim=dim, keepdim=True)
         X = X - max_val  # same numerical stability trick as for softmax
-        X = X / 2  # divide by 2 to solve actual Tsallis
+        X = X / 2  # divide by 2 to solve actual Entmax
 
-        tau_star, _ = _tsallis_threshold_and_support_topk(X, dim=dim, k=k)
+        tau_star, _ = _entmax_threshold_and_support_topk(X, dim=dim, k=k)
 
         Y = torch.clamp(X - tau_star, min=0) ** 2
         ctx.save_for_backward(Y)
@@ -286,65 +287,65 @@ class Tsallis15TopKFunction(Tsallis15Function):
 
     @staticmethod
     def backward(ctx, dY):
-        return Tsallis15Function.backward(ctx, dY) + (None,)
+        return Entmax15Function.backward(ctx, dY) + (None,)
 
 
-entmax15 = Tsallis15Function.apply
-entmax15_topk = Tsallis15TopKFunction.apply
+entmax15 = Entmax15Function.apply
+entmax15_topk = Entmax15TopKFunction.apply
 
 
-class Tsallis15(torch.nn.Module):
+class Entmax15(nn.Module):
 
     def __init__(self, dim=0):
         self.dim = dim
-        super(Tsallis15, self).__init__()
+        super(Entmax15, self).__init__()
 
     def forward(self, X):
         return entmax15(X, self.dim)
 
 
-class LogTsallis15(torch.nn.Module):
+class LogEntmax15(nn.Module):
 
     def __init__(self, dim=0):
         self.dim = dim
-        super(LogTsallis15, self).__init__()
+        super(LogEntmax15, self).__init__()
 
     def forward(self, X):
         return torch.log(entmax15(X, self.dim))
 
 
-class Tsallis15TopK(torch.nn.Module):
+class Entmax15TopK(nn.Module):
 
     def __init__(self, dim=0, k=100):
         self.dim = dim
         self.k = k
-        super(Tsallis15TopK, self).__init__()
+        super(Entmax15TopK, self).__init__()
 
     def forward(self, X):
         return entmax15_topk(X, self.dim, self.k)
 
 
-class LogTsallis15TopK(torch.nn.Module):
+class LogEntmax15TopK(nn.Module):
 
     def __init__(self, dim=0, k=100):
         self.dim = dim
         self.k = k
-        super(LogTsallis15TopK, self).__init__()
+        super(LogEntmax15TopK, self).__init__()
 
     def forward(self, X):
         return torch.log(entmax15_topk(X, self.dim, self.k))
 
 
-class LogTsallisBisect(nn.Module):
+class LogEntmaxBisect(nn.Module):
     def __init__(self, alpha=1.5, n_iter=50):
         self.alpha = alpha
         self.n_iter = n_iter
-        super(LogTsallisBisect, self).__init__()
+        super(LogEntmaxBisect, self).__init__()
 
     def forward(self, X):
         assert X.dim() == 2
 
-        p_star =  tsallis_bisect(X, self.alpha, self.n_iter)
+        p_star =  entmax_bisect(X, self.alpha, self.n_iter)
         p_star /= p_star.sum(dim=1).unsqueeze(dim=1)
 
         return torch.log(p_star)

--- a/entmax/activations.py
+++ b/entmax/activations.py
@@ -321,7 +321,7 @@ class Tsallis15TopK(torch.nn.Module):
         super(Tsallis15TopK, self).__init__()
 
     def forward(self, X):
-        return tsallis15_topk(X, self.dim, self.k)
+        return entmax15_topk(X, self.dim, self.k)
 
 
 class LogTsallis15TopK(torch.nn.Module):
@@ -332,7 +332,7 @@ class LogTsallis15TopK(torch.nn.Module):
         super(LogTsallis15TopK, self).__init__()
 
     def forward(self, X):
-        return torch.log(tsallis15_topk(X, self.dim, self.k))
+        return torch.log(entmax15_topk(X, self.dim, self.k))
 
 
 class LogTsallisBisect(nn.Module):

--- a/entmax/activations.py
+++ b/entmax/activations.py
@@ -11,7 +11,7 @@ By Ben Peters and Vlad Niculae
 import torch
 from torch.autograd import Function
 import torch.nn as nn
-from .root_finding import tsallis_bisect, sparsemax_bisect
+from entmax.root_finding import tsallis_bisect, sparsemax_bisect
 
 
 def _make_ix_like(input, dim=0):

--- a/entmax/losses.py
+++ b/entmax/losses.py
@@ -22,7 +22,7 @@ def _omega_tsallis(p_star, alpha):
 
 
 # more efficient specializations
-def _omega_tsallis15(p_star):
+def _omega_entmax15(p_star):
     return (1 - (p_star * torch.sqrt(p_star)).sum(dim=1)) / 0.75
 
 
@@ -151,7 +151,7 @@ class Tsallis15LossFunction(Function):
         input.shape[0] == target.shape[0]
 
         p_star = entmax15(input, 1)
-        loss = _omega_tsallis15(p_star)
+        loss = _omega_entmax15(p_star)
 
         p_star.scatter_add_(1, target.unsqueeze(1),
                             torch.full_like(p_star, -1))
@@ -177,8 +177,8 @@ class Tsallis15TopKLossFunction(Function):
         """
         assert input.shape[0] == target.shape[0]
 
-        p_star = tsallis15_topk(input, 1, k)
-        loss = _omega_tsallis15(p_star)
+        p_star = entmax15_topk(input, 1, k)
+        loss = _omega_entmax15(p_star)
 
         p_star.scatter_add_(1, target.unsqueeze(1),
                             torch.full_like(p_star, -1))
@@ -228,9 +228,9 @@ class TsallisBisectLossFunction(Function):
 sparsemax_loss = SparsemaxLossFunction.apply
 sparsemax_bisect_loss = SparsemaxBisectLossFunction.apply
 sparsemax_topk_loss = SparsemaxTopKLossFunction.apply
-tsallis15_loss = Tsallis15LossFunction.apply
+entmax15_loss = Tsallis15LossFunction.apply
 tsallis_bisect_loss = TsallisBisectLossFunction.apply
-tsallis15_topk_loss = Tsallis15TopKLossFunction.apply
+entmax15_topk_loss = Tsallis15TopKLossFunction.apply
 
 
 class SparsemaxLoss(_GenericLoss):
@@ -242,7 +242,7 @@ class SparsemaxLoss(_GenericLoss):
 class Tsallis15Loss(_GenericLoss):
 
     def loss(self, input, target):
-        return tsallis15_loss(input, target)
+        return entmax15_loss(input, target)
 
 
 class SparsemaxBisectLoss(_GenericLoss):
@@ -287,4 +287,4 @@ class Tsallis15TopKLoss(_GenericLoss):
         super(Tsallis15TopKLoss, self).__init__(weight, ignore_index, reduction)
 
     def loss(self, input, target):
-        return tsallis15_topk_loss(input, target, self.k)
+        return entmax15_topk_loss(input, target, self.k)

--- a/entmax/losses.py
+++ b/entmax/losses.py
@@ -8,7 +8,7 @@ from entmax.activations import (
     entmax15,
     entmax15_topk
 )
-from entmax.root_finding import tsallis_bisect, sparsemax_bisect
+from entmax.root_finding import entmax_bisect, sparsemax_bisect
 
 
 def _fy_backward(ctx, grad_output):
@@ -17,7 +17,7 @@ def _fy_backward(ctx, grad_output):
     return grad
 
 # computes Omega(y_true) - Omega(p*)
-def _omega_tsallis(p_star, alpha):
+def _omega_entmax(p_star, alpha):
     return (1 - (p_star ** alpha).sum(dim=1)) / (alpha * (alpha - 1))
 
 
@@ -140,7 +140,7 @@ class SparsemaxTopKLossFunction(Function):
         return _fy_backward(ctx, grad_output), None, None
 
 
-class Tsallis15LossFunction(Function):
+class Entmax15LossFunction(Function):
 
     @staticmethod
     def forward(ctx, input, target):
@@ -167,7 +167,7 @@ class Tsallis15LossFunction(Function):
         return _fy_backward(ctx, grad_output), None
 
 
-class Tsallis15TopKLossFunction(Function):
+class Entmax15TopKLossFunction(Function):
 
     @staticmethod
     def forward(ctx, input, target, k=100):
@@ -194,7 +194,7 @@ class Tsallis15TopKLossFunction(Function):
         return _fy_backward(ctx, grad_output), None, None
 
 
-class TsallisBisectLossFunction(Function):
+class EntmaxBisectLossFunction(Function):
 
     @staticmethod
     def forward(ctx, input, target, alpha=1.5, n_iter=50):
@@ -204,12 +204,12 @@ class TsallisBisectLossFunction(Function):
         """
         assert input.shape[0] == target.shape[0]
 
-        p_star = tsallis_bisect(input, alpha, n_iter)
+        p_star = entmax_bisect(input, alpha, n_iter)
 
-        # this is now done directly in tsallis_bisect
+        # this is now done directly in entmax_bisect
         # p_star /= p_star.sum(dim=1).unsqueeze(dim=1)
 
-        loss = _omega_tsallis(p_star, alpha)
+        loss = _omega_entmax(p_star, alpha)
 
         p_star.scatter_add_(1, target.unsqueeze(1),
                             torch.full_like(p_star, -1))
@@ -228,9 +228,9 @@ class TsallisBisectLossFunction(Function):
 sparsemax_loss = SparsemaxLossFunction.apply
 sparsemax_bisect_loss = SparsemaxBisectLossFunction.apply
 sparsemax_topk_loss = SparsemaxTopKLossFunction.apply
-entmax15_loss = Tsallis15LossFunction.apply
-tsallis_bisect_loss = TsallisBisectLossFunction.apply
-entmax15_topk_loss = Tsallis15TopKLossFunction.apply
+entmax15_loss = Entmax15LossFunction.apply
+entmax_bisect_loss = EntmaxBisectLossFunction.apply
+entmax15_topk_loss = Entmax15TopKLossFunction.apply
 
 
 class SparsemaxLoss(_GenericLoss):
@@ -239,7 +239,7 @@ class SparsemaxLoss(_GenericLoss):
         return sparsemax_loss(input, target)
 
 
-class Tsallis15Loss(_GenericLoss):
+class Entmax15Loss(_GenericLoss):
 
     def loss(self, input, target):
         return entmax15_loss(input, target)
@@ -267,24 +267,24 @@ class SparsemaxTopKLoss(_GenericLoss):
         return sparsemax_topk_loss(input, target, self.k)
 
 
-class TsallisBisectLoss(_GenericLoss):
+class EntmaxBisectLoss(_GenericLoss):
 
     def __init__(self, alpha=1.5, n_iter=50, weight=None, ignore_index=-100,
                  reduction='elementwise_mean'):
         self.alpha = alpha
         self.n_iter = n_iter
-        super(TsallisBisectLoss, self).__init__(weight, ignore_index, reduction)
+        super(EntmaxBisectLoss, self).__init__(weight, ignore_index, reduction)
 
     def loss(self, input, target):
-        return tsallis_bisect_loss(input, target, self.alpha, self.n_iter)
+        return entmax_bisect_loss(input, target, self.alpha, self.n_iter)
 
 
-class Tsallis15TopKLoss(_GenericLoss):
+class Entmax15TopKLoss(_GenericLoss):
 
     def __init__(self, k=100, weight=None, ignore_index=-100,
                  reduction='elementwise_mean'):
         self.k = k
-        super(Tsallis15TopKLoss, self).__init__(weight, ignore_index, reduction)
+        super(Entmax15TopKLoss, self).__init__(weight, ignore_index, reduction)
 
     def loss(self, input, target):
         return entmax15_topk_loss(input, target, self.k)

--- a/entmax/losses.py
+++ b/entmax/losses.py
@@ -1,13 +1,14 @@
 import torch
+import torch.nn as nn
 from torch.autograd import Function
 
-from .activations import (
+from entmax.activations import (
     sparsemax,
     sparsemax_topk,
     entmax15,
     entmax15_topk
 )
-from .root_finding import tsallis_bisect, sparsemax_bisect
+from entmax.root_finding import tsallis_bisect, sparsemax_bisect
 
 
 def _fy_backward(ctx, grad_output):
@@ -29,7 +30,7 @@ def _omega_sparsemax(p_star):
     return (1 - (p_star ** 2).sum(dim=1)) / 2
 
 
-class _GenericLoss(torch.nn.Module):
+class _GenericLoss(nn.Module):
 
     def __init__(self, weight=None, ignore_index=-100,
                  reduction='elementwise_mean'):

--- a/entmax/test_losses.py
+++ b/entmax/test_losses.py
@@ -3,7 +3,7 @@ import torch
 from torch.autograd import gradcheck, grad
 from functools import partial
 
-from losses import (
+from entmax.losses import (
     SparsemaxLoss,
     SparsemaxTopKLoss,
     Tsallis15Loss,

--- a/entmax/test_losses.py
+++ b/entmax/test_losses.py
@@ -6,10 +6,10 @@ from functools import partial
 from entmax.losses import (
     SparsemaxLoss,
     SparsemaxTopKLoss,
-    Tsallis15Loss,
-    Tsallis15TopKLoss,
+    Entmax15Loss,
+    Entmax15TopKLoss,
     SparsemaxBisectLoss,
-    TsallisBisectLoss,
+    EntmaxBisectLoss,
 )
 
 
@@ -23,10 +23,10 @@ ys = [torch.max(torch.randn_like(X), dim=1)[1] for X in Xs]
 losses = [
     SparsemaxLoss,
     partial(SparsemaxTopKLoss, k=5),
-    Tsallis15Loss,
-    partial(Tsallis15TopKLoss, k=5),
+    Entmax15Loss,
+    partial(Entmax15TopKLoss, k=5),
     SparsemaxBisectLoss,
-    TsallisBisectLoss,
+    EntmaxBisectLoss,
 ]
 
 
@@ -64,6 +64,6 @@ def test_index_ignored(Loss):
 
 if __name__ == '__main__':
     test_sparsemax_loss()
-    test_tsallis_loss()
+    test_entmax_loss()
     test_sparsemax_bisect_loss()
-    test_tsallis_bisect_loss()
+    test_entmax_bisect_loss()

--- a/entmax/test_mask.py
+++ b/entmax/test_mask.py
@@ -1,9 +1,11 @@
 import torch
 import pytest
 
-from activations import Sparsemax, Tsallis15, SparsemaxTopK, Tsallis15TopK
+from entmax.activations import (
+    Sparsemax, Tsallis15, SparsemaxTopK, Tsallis15TopK
+)
 
-from root_finding import sparsemax_bisect, tsallis_bisect
+from entmax.root_finding import sparsemax_bisect, tsallis_bisect
 
 funcs = [
     Sparsemax(dim=1),

--- a/entmax/test_mask.py
+++ b/entmax/test_mask.py
@@ -2,18 +2,18 @@ import torch
 import pytest
 
 from entmax.activations import (
-    Sparsemax, Tsallis15, SparsemaxTopK, Tsallis15TopK
+    Sparsemax, Entmax15, SparsemaxTopK, Entmax15TopK
 )
 
-from entmax.root_finding import sparsemax_bisect, tsallis_bisect
+from entmax.root_finding import sparsemax_bisect, entmax_bisect
 
 funcs = [
     Sparsemax(dim=1),
-    Tsallis15(dim=1),
+    Entmax15(dim=1),
     SparsemaxTopK(dim=1),
-    Tsallis15TopK(dim=1),
+    Entmax15TopK(dim=1),
     sparsemax_bisect,
-    tsallis_bisect,
+    entmax_bisect,
 ]
 
 
@@ -40,8 +40,8 @@ def test_mask_alphas(alpha):
     x[:, 3:] = -float('inf')
     x0 = x[:, :3]
 
-    y = tsallis_bisect(x, alpha)
-    y0 = tsallis_bisect(x0, alpha)
+    y = entmax_bisect(x, alpha)
+    y0 = entmax_bisect(x0, alpha)
 
     y[:, :3] -= y0
 

--- a/entmax/test_root_finding.py
+++ b/entmax/test_root_finding.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 from torch.autograd import gradcheck
 
-from entmax.root_finding import sparsemax_bisect, tsallis_bisect
+from entmax.root_finding import sparsemax_bisect, entmax_bisect
 
 from entmax.activations import sparsemax, entmax15
 
@@ -16,11 +16,11 @@ def test_sparsemax():
         assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 
-def test_tsallis15():
+def test_entmax15():
     for _ in range(10):
         x = 0.5 * torch.randn(10, 30000, dtype=torch.float32)
         p1 = entmax15(x, 1)
-        p2 = tsallis_bisect(x, 1.5)
+        p2 = entmax_bisect(x, 1.5)
         assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 
@@ -33,11 +33,11 @@ def test_sparsemax_grad():
 
 
 @pytest.mark.parametrize('alpha', (1.2, 1.5, 1.75, 2.25))
-def test_tsallis_grad(alpha):
+def test_entmax_grad(alpha):
 
     for _ in range(10):
 
         x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
         _, y = torch.max(torch.randn_like(x), dim=1)
 
-        gradcheck(tsallis_bisect, (x, alpha), eps=1e-5)
+        gradcheck(entmax_bisect, (x, alpha), eps=1e-5)

--- a/entmax/test_root_finding.py
+++ b/entmax/test_root_finding.py
@@ -3,9 +3,9 @@ import pytest
 import torch
 from torch.autograd import gradcheck
 
-from root_finding import sparsemax_bisect, tsallis_bisect
+from entmax.root_finding import sparsemax_bisect, tsallis_bisect
 
-from activations import sparsemax, entmax15
+from entmax.activations import sparsemax, entmax15
 
 
 def test_sparsemax():

--- a/entmax/test_topk.py
+++ b/entmax/test_topk.py
@@ -3,7 +3,7 @@ import torch
 from torch.autograd import gradcheck
 
 
-from activations import (
+from entmax.activations import (
     _threshold_and_support,
     _threshold_and_support_topk,
     _tsallis_threshold_and_support,
@@ -12,7 +12,7 @@ from activations import (
     Tsallis15TopK,
 )
 
-from losses import (
+from entmax.losses import (
     SparsemaxLoss,
     SparsemaxTopKLoss,
     Tsallis15Loss,

--- a/entmax/test_topk.py
+++ b/entmax/test_topk.py
@@ -6,22 +6,22 @@ from torch.autograd import gradcheck
 from entmax.activations import (
     _threshold_and_support,
     _threshold_and_support_topk,
-    _tsallis_threshold_and_support,
-    _tsallis_threshold_and_support_topk,
+    _entmax_threshold_and_support,
+    _entmax_threshold_and_support_topk,
     SparsemaxTopK,
-    Tsallis15TopK,
+    Entmax15TopK,
 )
 
 from entmax.losses import (
     SparsemaxLoss,
     SparsemaxTopKLoss,
-    Tsallis15Loss,
-    Tsallis15TopKLoss,
+    Entmax15Loss,
+    Entmax15TopKLoss,
 )
 
 
 @pytest.mark.parametrize('dim', (0, 1, 2))
-@pytest.mark.parametrize('Map', (SparsemaxTopK, Tsallis15TopK))
+@pytest.mark.parametrize('Map', (SparsemaxTopK, Entmax15TopK))
 def test_mapping(dim, Map):
     f = Map(dim=dim, k=3)
 
@@ -32,10 +32,10 @@ def test_mapping(dim, Map):
 
 @pytest.mark.parametrize('dim', (0, 1, 2))
 @pytest.mark.parametrize('coef', (0.00001, 0.5, 10000))
-def test_tsallis_topk(dim, coef):
+def test_entmax_topk(dim, coef):
     x = coef * torch.randn(10, 11, 12)
-    tau1, supp1 = _tsallis_threshold_and_support(x, dim=dim)
-    tau2, supp2 = _tsallis_threshold_and_support_topk(x, dim=dim, k=5)
+    tau1, supp1 = _entmax_threshold_and_support(x, dim=dim)
+    tau2, supp2 = _entmax_threshold_and_support_topk(x, dim=dim, k=5)
 
     assert torch.all(tau1 == tau2)
     assert torch.all(supp1 == supp2)
@@ -83,23 +83,23 @@ def check_speed():
 
     args = dict(reduction='sum', ignore_index=ix)
 
-    from losses import SparsemaxBisectLoss, TsallisBisectLoss
+    from losses import SparsemaxBisectLoss, EntmaxBisectLoss
 
     sp1 = partial(SparsemaxLoss(**args), input=x, target=y)
     sp2 = partial(SparsemaxTopKLoss(k=k, **args), input=x, target=y)
     sp3 = partial(SparsemaxBisectLoss(n_iter=n_iter, **args), input=x, target=y)
-    ts1 = partial(Tsallis15Loss(**args), input=x, target=y)
-    ts2 = partial(Tsallis15TopKLoss(k=k, **args), input=x, target=y)
-    ts3 = partial(TsallisBisectLoss(alpha=1.5, n_iter=n_iter, **args), input=x, target=y)
+    ts1 = partial(Entmax15Loss(**args), input=x, target=y)
+    ts2 = partial(Entmax15TopKLoss(k=k, **args), input=x, target=y)
+    ts3 = partial(EntmaxBisectLoss(alpha=1.5, n_iter=n_iter, **args), input=x, target=y)
 
     torch.cuda.synchronize()
     torch.cuda.synchronize()
     print("sparsemax topk", _bench(sp2))
     print("sparsemax full", _bench(sp1))
     print("sparsemax bis ", _bench(sp3))
-    print("tsallis15 topk", _bench(ts2))
-    print("tsallis15 full", _bench(ts1))
-    print("tsallis15 bis ", _bench(ts3))
+    print("entmax15 topk", _bench(ts2))
+    print("entmax15 full", _bench(ts1))
+    print("entmax15 bis ", _bench(ts3))
 
     print(((sp1() - sp2()) ** 2).sum())
     print(((sp1() - sp3()) ** 2).sum())


### PR DESCRIPTION
This change reflects the final name we selected for the function and removes references to the word "Tsallis" in both functions and modules.