### PR TITLE
Gradient wrt alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In [1]: import torch
 
 In [2]: from torch.nn.functional import softmax
 
-In [2]: from entmax.activations import sparsemax, entmax15, entmax_bisect
+In [2]: from entmax import sparsemax, entmax15, entmax_bisect
 
 In [4]: x = torch.tensor([-2, 0, 0.5])
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ generalizing softmax / cross-entropy.
 *Features:*
   - Exact partial-sort algorithms for 1.5-entmax and 2-entmax (sparsemax).
   - A bisection-based algorithm for generic alpha-entmax.
+  - Gradients w.r.t. alpha for adaptive, learned sparsity!
 
 *Requirements:* python 3, pytorch >= 1.0 (and pytest for unit tests)
 
@@ -34,7 +35,7 @@ In [7]: entmax15(x, dim=0)
 Out[7]: tensor([0.0000, 0.3260, 0.6740])
 ```
 
-## Citation
+## Citations
 
 [Sparse Sequence-to-Sequence Models](https://www.aclweb.org/anthology/P19-1146)
 
@@ -45,6 +46,17 @@ Out[7]: tensor([0.0000, 0.3260, 0.6740])
   booktitle = {Proc. ACL},
   year      = {2019},
   url       = {https://www.aclweb.org/anthology/P19-1146}
+}
+```
+
+Adaptively Sparse Transformers
+
+```
+@inproceedings{correia19adaptively,
+  author    = {Correia, Gon\c{c}alo M and Niculae, Vlad and Martins, Andr{\'e} FT},
+  title     = {Adaptively Sparse Transformers},
+  booktitle = {Proc. EMNLP-IJCNLP (to appear)},
+  year      = {2019},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ generalizing softmax / cross-entropy.
 ## Example
 
 ```python
-In [1]: from torch.nn.functional import softmax
+In [1]: import torch
 
-In [2]: from entmax.activations import sparsemax, entmax15
+In [2]: from torch.nn.functional import softmax
 
-In [3]: import torch
+In [2]: from entmax.activations import sparsemax, entmax15, entmax_bisect
 
 In [4]: x = torch.tensor([-2, 0, 0.5])
 
@@ -33,7 +33,29 @@ Out[6]: tensor([0.0000, 0.2500, 0.7500])
 
 In [7]: entmax15(x, dim=0)
 Out[7]: tensor([0.0000, 0.3260, 0.6740])
+
 ```
+
+Gradients w.r.t. alpha (continued):
+
+```python
+In [1]: from torch.autograd import grad
+
+In [2]: x = torch.tensor([[-1, 0, 0.5], [1, 2, 3.5]])
+
+In [3]: alpha = torch.tensor(1.33, requires_grad=True)
+
+In [4]: p = entmax_bisect(x, alpha)
+
+In [5]: p
+Out[5]:
+tensor([[0.0460, 0.3276, 0.6264],
+        [0.0026, 0.1012, 0.8963]], grad_fn=<EntmaxBisectFunctionBackward>)
+
+In [6]: grad(p[0, 0], alpha)
+Out[6]: (tensor(-0.2562),)
+```
+
 
 ## Citations
 

--- a/entmax/__init__.py
+++ b/entmax/__init__.py
@@ -1,2 +1,17 @@
-from entmax.activations import sparsemax, entmax15
-from entmax.losses import sparsemax_loss
+from entmax.activations import sparsemax, entmax15, Sparsemax, Entmax15
+from entmax.root_finding import (
+    sparsemax_bisect,
+    entmax_bisect,
+    SparsemaxBisect,
+    EntmaxBisect,
+)
+from entmax.losses import (
+    sparsemax_loss,
+    entmax15_loss,
+    sparsemax_bisect_loss,
+    entmax_bisect_loss,
+    SparsemaxLoss,
+    SparsemaxBisectLoss,
+    Entmax15Loss,
+    EntmaxBisectLoss,
+)

--- a/entmax/activations.py
+++ b/entmax/activations.py
@@ -4,9 +4,11 @@ https://arxiv.org/pdf/1905.05702 for detailed description.
 
 This builds on previous work with sparsemax (Martins & Astudillo, 2016).
 See https://arxiv.org/pdf/1602.02068.
-
-By Ben Peters and Vlad Niculae
 """
+
+# Author: Ben Peters
+# Author: Vlad Niculae <vlad@vene.ro>
+# License: MIT
 
 import torch
 import torch.nn as nn

--- a/entmax/activations.py
+++ b/entmax/activations.py
@@ -347,9 +347,7 @@ class LogEntmaxBisect(nn.Module):
     def forward(self, X):
         assert X.dim() == 2
 
-        p_star = entmax_bisect(X, self.alpha, self.n_iter)
-        p_star /= p_star.sum(dim=1).unsqueeze(dim=1)
-
+        p_star = entmax_bisect(X, self.alpha, self.n_iter, ensure_sum_one=True)
         return torch.log(p_star)
 
 
@@ -361,7 +359,5 @@ class LogSparsemaxBisect(nn.Module):
     def forward(self, X):
         assert X.dim() == 2
 
-        p_star = sparsemax_bisect(X, self.n_iter)
-        p_star /= p_star.sum(dim=1).unsqueeze(dim=1)
-
+        p_star = sparsemax_bisect(X, self.n_iter, ensure_sum_one=True)
         return torch.log(p_star)

--- a/entmax/losses.py
+++ b/entmax/losses.py
@@ -87,7 +87,9 @@ class SparsemaxBisectLossFunction(_GenericLossFunction):
 
     @classmethod
     def forward(cls, ctx, X, target, n_iter=50):
-        return super().forward(ctx, X, target, alpha=2, proj_args=dict(n_iter=n_iter))
+        return super().forward(
+            ctx, X, target, alpha=2, proj_args=dict(n_iter=n_iter)
+        )
 
 
 class Entmax15LossFunction(_GenericLossFunction):
@@ -121,7 +123,9 @@ class EntmaxBisectLossFunction(_GenericLossFunction):
 
     @classmethod
     def forward(cls, ctx, X, target, alpha=1.5, n_iter=50):
-        return super().forward(ctx, X, target, alpha, proj_args=dict(n_iter=n_iter))
+        return super().forward(
+            ctx, X, target, alpha, proj_args=dict(n_iter=n_iter)
+        )
 
 
 def sparsemax_loss(X, target, k=None):
@@ -237,7 +241,9 @@ def entmax_bisect_loss(X, target, alpha=1.5, n_iter=50):
 
 
 class SparsemaxBisectLoss(_GenericLoss):
-    def __init__(self, n_iter=50, ignore_index=-100, reduction="elementwise_mean"):
+    def __init__(
+        self, n_iter=50, ignore_index=-100, reduction="elementwise_mean"
+    ):
         self.n_iter = n_iter
         super(SparsemaxBisectLoss, self).__init__(ignore_index, reduction)
 
@@ -256,7 +262,11 @@ class SparsemaxLoss(_GenericLoss):
 
 class EntmaxBisectLoss(_GenericLoss):
     def __init__(
-        self, alpha=1.5, n_iter=50, ignore_index=-100, reduction="elementwise_mean"
+        self,
+        alpha=1.5,
+        n_iter=50,
+        ignore_index=-100,
+        reduction="elementwise_mean",
     ):
         self.alpha = alpha
         self.n_iter = n_iter

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -112,8 +112,8 @@ class SparsemaxBisectFunction(EntmaxBisectFunction):
     def forward(cls, ctx, X, n_iter=50, ensure_sum_one=True):
         return super().forward(ctx, X, alpha=2, n_iter=50, ensure_sum_one=True)
 
-    @staticmethod
-    def backward(ctx, dY):
+    @classmethod
+    def backward(cls, ctx, dY):
         Y, = ctx.saved_tensors
         gppr = (Y > 0).to(dtype=dY.dtype)
         dX = dY * gppr

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -12,13 +12,13 @@ from torch.autograd import Function
 
 
 class EntmaxBisectFunction(Function):
-
     @classmethod
     def _gp(cls, x, alpha):
         return x ** (alpha - 1)
 
     @classmethod
-    def _gp_inv(cls, y, alpha): return y ** (1 / (alpha - 1))
+    def _gp_inv(cls, y, alpha):
+        return y ** (1 / (alpha - 1))
 
     @classmethod
     def _p(cls, X, alpha):
@@ -96,7 +96,6 @@ class EntmaxBisectFunction(Function):
 
 # slightly more efficient special case for sparsemax
 class SparsemaxBisectFunction(EntmaxBisectFunction):
-
     @classmethod
     def _gp(cls, x, alpha):
         return x
@@ -104,7 +103,6 @@ class SparsemaxBisectFunction(EntmaxBisectFunction):
     @classmethod
     def _gp_inv(cls, y, alpha):
         return y
-
 
     @classmethod
     def _p(cls, x, alpha):
@@ -198,4 +196,3 @@ def sparsemax_bisect(X, n_iter=50, ensure_sum_one=True):
         The projection result, such that P.sum(dim=-1) == 1 elementwise.
     """
     return SparsemaxBisectFunction.apply(X, n_iter, ensure_sum_one)
-

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -129,7 +129,7 @@ class SparsemaxBisectFunction(EntmaxBisectFunction):
         return dX, None, None, None
 
 
-def entmax_bisect(X, alpha=1.5, dim=1, n_iter=50, ensure_sum_one=True):
+def entmax_bisect(X, alpha=1.5, dim=-1, n_iter=50, ensure_sum_one=True):
     """alpha-entmax: normalizing sparse transform (a la softmax).
 
     Solves the optimization problem:

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -116,7 +116,9 @@ class SparsemaxBisectFunction(EntmaxBisectFunction):
 
     @classmethod
     def forward(cls, ctx, X, dim=-1, n_iter=50, ensure_sum_one=True):
-        return super().forward(ctx, X, alpha=2, dim=dim, n_iter=50, ensure_sum_one=True)
+        return super().forward(
+            ctx, X, alpha=2, dim=dim, n_iter=50, ensure_sum_one=True
+        )
 
     @classmethod
     def backward(cls, ctx, dY):
@@ -234,7 +236,7 @@ class SparsemaxBisect(nn.Module):
 
 
 class EntmaxBisect(nn.Module):
-    def __init__(self, dim=-1, n_iter=50):
+    def __init__(self, alpha=1.5, dim=-1, n_iter=50):
         """alpha-entmax: normalizing sparse map (a la softmax) via bisection.
 
         Solves the optimization problem:
@@ -246,6 +248,14 @@ class EntmaxBisect(nn.Module):
 
         Parameters
         ----------
+        alpha : float or torch.Tensor
+            Tensor of alpha parameters (> 1) to use. If scalar
+            or python float, the same value is used for all rows, otherwise,
+            it must have shape (or be expandable to)
+            alpha.shape[j] == (X.shape[j] if j != dim else 1)
+            A value of alpha=2 corresponds to sparsemax, and alpha=1 corresponds
+            to softmax (but computing it this way is likely unstable).
+
         dim : int
             The dimension along which to apply alpha-entmax.
 
@@ -256,7 +266,10 @@ class EntmaxBisect(nn.Module):
         """
         self.dim = dim
         self.n_iter = n_iter
+        self.alpha = alpha
         super().__init__()
 
     def forward(self, X, alpha):
-        return entmax_bisect(X, alpha=alpha, dim=self.dim, n_iter=self.n_iter)
+        return entmax_bisect(
+            X, alpha=self.alpha, dim=self.dim, n_iter=self.n_iter
+        )

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -1,4 +1,12 @@
-# bisection
+"""
+Bisection implementation of alpha-entmax (Peters et al., 2019).
+Backward pass wrt alpha per (Correia et al., 2019). See
+https://arxiv.org/pdf/1905.05702 for detailed description.
+"""
+# Author: Goncalo M Correia
+# Author: Ben Peters
+# Author: Vlad Niculae <vlad@vene.ro>
+
 import torch
 from torch.autograd import Function
 

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -3,48 +3,37 @@ import torch
 from torch.autograd import Function
 
 
-def assert_equal(*args):
-    """
-    Assert all arguments have the same value
-    """
-    arguments = (arg for arg in args)
-    first = next(arguments)
-    assert all(
-        arg == first for arg in arguments
-    ), "Not all arguments have the same value: " + str(args)
+class EntmaxBisectFunction(Function):
 
+    @classmethod
+    def _gp(cls, x, alpha):
+        return x ** (alpha - 1)
 
-def _p(x, tau):
-    return torch.clamp(x - tau, min=0)
+    @classmethod
+    def _gp_inv(cls, y, alpha): return y ** (1 / (alpha - 1))
 
+    @classmethod
+    def _p(cls, X, alpha):
+        return cls._gp_inv(torch.clamp(X, min=0), alpha)
 
-def _entmax_gp(x, alpha):
-    return x ** (alpha - 1)
+    @classmethod
+    def forward(cls, ctx, X, alpha=1.5, n_iter=50, ensure_sum_one=True):
 
-
-def _entmax_gp_inv(y, alpha):
-    return y ** (1 / (alpha - 1))
-
-
-def _entmax_p(X, alpha):
-    return _entmax_gp_inv(torch.clamp(X, min=0), alpha)
-
-
-# TODO: support other dims other than 1. The code likely same, but needs tested
-class SparsemaxBisectFunction(Function):
-    @staticmethod
-    def forward(ctx, X, n_iter=50, ensure_sum_one=True):
-
+        if not isinstance(alpha, torch.Tensor):
+            alpha = torch.tensor(alpha, dtype=X.dtype)
+        alpha = alpha.unsqueeze(-1)  # different alpha per row
+        ctx.alpha = alpha
         ctx.dim = dim = 1
         d = X.shape[dim]
 
+        X = X * (alpha - 1)
+
         max_val, _ = X.max(dim=dim, keepdim=True)
 
-        tau_lo = max_val - 1
-        tau_hi = max_val - (1 / d)
+        tau_lo = max_val - cls._gp(1, alpha)
+        tau_hi = max_val - cls._gp(1 / d, alpha)
 
-        f_lo = _p(X, tau_lo).sum(dim) - 1
-        f_hi = _p(X, tau_hi).sum(dim) - 1
+        f_lo = cls._p(X - tau_lo, alpha).sum(dim) - 1
 
         dm = tau_hi - tau_lo
 
@@ -52,7 +41,7 @@ class SparsemaxBisectFunction(Function):
 
             dm /= 2
             tau_m = tau_lo + dm
-            p_m = _p(X, tau_m)
+            p_m = cls._p(X - tau_m, alpha)
             f_m = p_m.sum(dim) - 1
 
             mask = (f_m * f_lo >= 0).unsqueeze(dim)
@@ -64,6 +53,58 @@ class SparsemaxBisectFunction(Function):
         ctx.save_for_backward(p_m)
 
         return p_m
+
+    @classmethod
+    def backward(cls, ctx, dY):
+        Y, = ctx.saved_tensors
+
+        gppr = torch.where(Y > 0, Y ** (2 - ctx.alpha), Y.new_zeros(1))
+
+        dX = dY * gppr
+        q = dX.sum(ctx.dim) / gppr.sum(ctx.dim)
+        q = q.unsqueeze(ctx.dim)
+        dX -= q * gppr
+
+        d_alpha = None
+        if ctx.needs_input_grad[1]:
+
+            # alpha gradient computation
+            # d_alpha = (partial_y / partial_alpha) * dY
+            # NOTE: ensure alpha is not close to 1
+            # since there is an indetermination
+            batch_size, _ = dY.shape
+
+            # shannon terms
+            S = torch.where(Y > 0, Y * torch.log(Y), Y.new_zeros(1))
+            # shannon entropy
+            ent = S.sum(ctx.dim).unsqueeze(-1)
+            Y_skewed = gppr / gppr.sum(ctx.dim).unsqueeze(-1)
+            d_alpha = dY * (Y - Y_skewed) / ((ctx.alpha - 1) ** 2)
+            d_alpha -= dY * (S - Y_skewed * ent) / (ctx.alpha - 1)
+            d_alpha = d_alpha.sum(dim=-1)
+
+        return dX, d_alpha, None, None
+
+
+# slightly more efficient special case for sparsemax
+class SparsemaxBisectFunction(EntmaxBisectFunction):
+
+    @classmethod
+    def _gp(cls, x, alpha):
+        return x
+
+    @classmethod
+    def _gp_inv(cls, y, alpha):
+        return y
+
+
+    @classmethod
+    def _p(cls, x, alpha):
+        return torch.clamp(x, min=0)
+
+    @classmethod
+    def forward(cls, ctx, X, n_iter=50, ensure_sum_one=True):
+        return super().forward(ctx, X, alpha=2, n_iter=50, ensure_sum_one=True)
 
     @staticmethod
     def backward(ctx, dY):
@@ -73,60 +114,80 @@ class SparsemaxBisectFunction(Function):
         q = dX.sum(ctx.dim) / gppr.sum(ctx.dim)
         q = q.unsqueeze(ctx.dim)
         dX -= q * gppr
-        return dX, None
-
-
-class EntmaxBisectFunction(Function):
-    @staticmethod
-    def forward(ctx, X, alpha=1.5, n_iter=50, ensure_sum_one=True):
-
-        ctx.alpha = alpha
-        ctx.dim = dim = 1
-        d = X.shape[dim]
-
-        X = X * (alpha - 1)
-
-        max_val, _ = X.max(dim=dim, keepdim=True)
-
-        minv = _entmax_gp(0, alpha)
-
-        tau_lo = max_val - _entmax_gp(1, alpha)
-        tau_hi = max_val - _entmax_gp(1 / d, alpha)
-
-        f_lo = _entmax_p(X - tau_lo, alpha).sum(dim) - 1
-        f_hi = _entmax_p(X - tau_hi, alpha).sum(dim) - 1
-
-        dm = tau_hi - tau_lo
-
-        for it in range(n_iter):
-
-            dm /= 2
-            tau_m = tau_lo + dm
-            p_m = _entmax_p(X - tau_m, alpha)
-            f_m = p_m.sum(dim) - 1
-
-            mask = (f_m * f_lo >= 0).unsqueeze(dim)
-            tau_lo = torch.where(mask, tau_m, tau_lo)
-
-        if ensure_sum_one:
-            p_m /= p_m.sum(dim=1).unsqueeze(dim=1)
-
-        ctx.save_for_backward(p_m)
-
-        return p_m
-
-    @staticmethod
-    def backward(ctx, dY):
-        Y, = ctx.saved_tensors
-
-        gppr = torch.where(Y > 0, Y ** (2 - ctx.alpha), Y.new_zeros(1))
-
-        dX = dY * gppr
-        q = dX.sum(ctx.dim) / gppr.sum(ctx.dim)
-        q = q.unsqueeze(ctx.dim)
-        dX -= q * gppr
         return dX, None, None
 
 
-sparsemax_bisect = SparsemaxBisectFunction.apply
-entmax_bisect = EntmaxBisectFunction.apply
+def entmax_bisect(X, alpha=1.5, n_iter=50, ensure_sum_one=True):
+    """alpha-entmax: normalizing sparse transform (a la softmax).
+
+    Solves the optimization problem:
+
+        max_p <x, p> - H_a(p)    s.t.    p >= 0, sum(p) == 1.
+
+    where H_a(p) is the Tsallis alpha-entropy with custom alpha >= 1,
+    using a bisection (root finding, binary search) algorithm.
+
+    This function is differentiable with respect to both X and alpha.
+
+    Note: This function does not yet support normalizing along anything except
+    the last dimension. Please use transposing and views to achieve more general
+    behavior.
+
+    Parameters
+    ----------
+    X : torch.Tensor
+        The input 2D tensor, to be normalized along the last dimension.
+
+    alpha : float or torch.Tensor
+        Tensor of alpha parameters (> 1) to use for each row of X. If scalar
+        or python float, the same value is used for all rows. A value of
+        alpha=2 corresponds to sparsemax, and alpha=1 corresponds to softmax
+        (but computing it this way is likely unstable).
+
+    n_iter : int
+        Number of bisection iterations. For float32, 24 iterations should
+        suffice for machine precision.
+
+    ensure_sum_one : bool,
+        Whether to divide the result by its sum. If false, the result might
+        sum to close but not exactly 1, which might cause downstream problems.
+
+    Returns
+    -------
+    P : torch tensor, same shape as X
+        The projection result, such that P.sum(dim=-1) == 1 elementwise.
+    """
+    return EntmaxBisectFunction.apply(X, alpha, n_iter, ensure_sum_one)
+
+
+def sparsemax_bisect(X, n_iter=50, ensure_sum_one=True):
+    """sparsemax: normalizing sparse transform (a la softmax), via bisection.
+
+    Solves the projection:
+
+        min_p ||x - p||_2   s.t.    p >= 0, sum(p) == 1.
+
+    Parameters
+    ----------
+    X : torch.Tensor
+        The input tensor.
+
+    n_iter : int
+        Number of bisection iterations. For float32, 24 iterations should
+        suffice for machine precision.
+
+    ensure_sum_one : bool,
+        Whether to divide the result by its sum. If false, the result might
+        sum to close but not exactly 1, which might cause downstream problems.
+
+    Note: This function does not yet support normalizing along anything except
+    the last dimension. Please use transposing and views to achieve more general
+    behavior.
+
+    Returns
+    -------
+    P : torch tensor, same shape as X
+        The projection result, such that P.sum(dim=-1) == 1 elementwise.
+    """
+    return SparsemaxBisectFunction.apply(X, n_iter, ensure_sum_one)
+

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -29,7 +29,7 @@ class EntmaxBisectFunction(Function):
     def forward(cls, ctx, X, alpha=1.5, dim=-1, n_iter=50, ensure_sum_one=True):
 
         if not isinstance(alpha, torch.Tensor):
-            alpha = torch.tensor(alpha, dtype=X.dtype)
+            alpha = torch.tensor(alpha, dtype=X.dtype, device=X.device)
 
         alpha_shape = list(X.shape)
         alpha_shape[dim] = 1

--- a/entmax/test_losses.py
+++ b/entmax/test_losses.py
@@ -12,7 +12,10 @@ from entmax.losses import (
 
 
 # make data
-Xs = [torch.randn(4, 10, dtype=torch.float64, requires_grad=True) for _ in range(10)]
+Xs = [
+    torch.randn(4, 10, dtype=torch.float64, requires_grad=True)
+    for _ in range(5)
+]
 
 ys = [torch.max(torch.randn_like(X), dim=1)[1] for X in Xs]
 

--- a/entmax/test_root_finding.py
+++ b/entmax/test_root_finding.py
@@ -17,37 +17,29 @@ from entmax.activations import sparsemax, entmax15
 
 
 def test_sparsemax():
-    for _ in range(10):
-        x = 0.5 * torch.randn(10, 30000, dtype=torch.float32)
-        p1 = sparsemax(x, 1)
-        p2 = sparsemax_bisect(x)
-        assert torch.sum((p1 - p2) ** 2) < 1e-7
+    x = 0.5 * torch.randn(4, 6, dtype=torch.float32)
+    p1 = sparsemax(x, 1)
+    p2 = sparsemax_bisect(x)
+    assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 
 def test_entmax15():
-    for _ in range(10):
-        x = 0.5 * torch.randn(10, 30000, dtype=torch.float32)
-        p1 = entmax15(x, 1)
-        p2 = entmax_bisect(x, alpha=1.5)
-        assert torch.sum((p1 - p2) ** 2) < 1e-7
+    x = 0.5 * torch.randn(4, 6, dtype=torch.float32)
+    p1 = entmax15(x, 1)
+    p2 = entmax_bisect(x, alpha=1.5)
+    assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 
 def test_sparsemax_grad():
-
-    for _ in range(10):
-
-        x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
-        gradcheck(sparsemax_bisect, (x,), eps=1e-5)
+    x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
+    gradcheck(sparsemax_bisect, (x,), eps=1e-5)
 
 
 @pytest.mark.parametrize("alpha", (1.2, 1.5, 1.75, 2.25))
 def test_entmax_grad(alpha):
-
     alpha = torch.tensor(alpha, dtype=torch.float64, requires_grad=True)
-
-    for _ in range(10):
-        x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
-        gradcheck(entmax_bisect, (x, alpha), eps=1e-5)
+    x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
+    gradcheck(entmax_bisect, (x, alpha), eps=1e-5)
 
 
 def test_entmax_correct_multiple_alphas():
@@ -57,7 +49,8 @@ def test_entmax_correct_multiple_alphas():
 
     p1 = entmax_bisect(x, alpha)
     p2_ = [
-        entmax_bisect(x[i].unsqueeze(0), alpha[i].item()).squeeze() for i in range(n)
+        entmax_bisect(x[i].unsqueeze(0), alpha[i].item()).squeeze()
+        for i in range(n)
     ]
     p2 = torch.stack(p2_)
 
@@ -67,10 +60,9 @@ def test_entmax_correct_multiple_alphas():
 def test_entmax_grad_multiple_alphas():
 
     n = 4
-    for _ in range(10):
-        x = torch.randn(n, 6, dtype=torch.float64, requires_grad=True)
-        alpha = 1.05 + torch.rand((n, 1), dtype=torch.float64, requires_grad=True)
-        gradcheck(entmax_bisect, (x, alpha), eps=1e-5)
+    x = torch.randn(n, 6, dtype=torch.float64, requires_grad=True)
+    alpha = 1.05 + torch.rand((n, 1), dtype=torch.float64, requires_grad=True)
+    gradcheck(entmax_bisect, (x, alpha), eps=1e-5)
 
 
 @pytest.mark.parametrize("dim", (0, 1, 2, 3))
@@ -86,7 +78,8 @@ def test_arbitrary_dimension(dim):
     P = entmax_bisect(X, alpha=alphas, dim=dim)
 
     ranges = [
-        list(range(k)) if i != dim else [slice(None)] for i, k in enumerate(shape)
+        list(range(k)) if i != dim else [slice(None)]
+        for i, k in enumerate(shape)
     ]
 
     for ix in product(*ranges):
@@ -105,7 +98,8 @@ def test_arbitrary_dimension_grad(dim):
 
     f = partial(entmax_bisect, dim=dim)
 
-    for _ in range(10):
-        X = torch.randn(*shape, dtype=torch.float64, requires_grad=True)
-        alphas = 1.05 + torch.rand(alpha_shape, dtype=torch.float64, requires_grad=True)
-        gradcheck(f, (X, alphas), eps=1e-5)
+    X = torch.randn(*shape, dtype=torch.float64, requires_grad=True)
+    alphas = 1.05 + torch.rand(
+        alpha_shape, dtype=torch.float64, requires_grad=True
+    )
+    gradcheck(f, (X, alphas), eps=1e-5)

--- a/entmax/test_root_finding.py
+++ b/entmax/test_root_finding.py
@@ -48,8 +48,9 @@ def test_entmax_correct_multiple_alphas():
     alpha = 1.05 + torch.rand(n, dtype=torch.float64, requires_grad=True)
 
     p1 = entmax_bisect(x, alpha)
-    p2_ = [entmax_bisect(x[i].unsqueeze(0), alpha[i].item()).squeeze()
-            for i in range(n)]
+    p2_ = [
+        entmax_bisect(x[i].unsqueeze(0), alpha[i].item()).squeeze() for i in range(n)
+    ]
     p2 = torch.stack(p2_)
 
     assert torch.allclose(p1, p2)
@@ -61,4 +62,3 @@ def test_entmax_grad_multiple_alphas():
         x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
         alpha = 1.05 + torch.rand(4, dtype=torch.float64, requires_grad=True)
         gradcheck(entmax_bisect, (x, alpha), eps=1e-5)
-

--- a/entmax/test_root_finding.py
+++ b/entmax/test_root_finding.py
@@ -20,7 +20,7 @@ def test_entmax15():
     for _ in range(10):
         x = 0.5 * torch.randn(10, 30000, dtype=torch.float32)
         p1 = entmax15(x, 1)
-        p2 = entmax_bisect(x, 1.5)
+        p2 = entmax_bisect(x, alpha=1.5)
         assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 
@@ -35,9 +35,30 @@ def test_sparsemax_grad():
 @pytest.mark.parametrize("alpha", (1.2, 1.5, 1.75, 2.25))
 def test_entmax_grad(alpha):
 
+    alpha = torch.tensor(alpha, dtype=torch.float64, requires_grad=True)
+
     for _ in range(10):
-
         x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
-        _, y = torch.max(torch.randn_like(x), dim=1)
-
         gradcheck(entmax_bisect, (x, alpha), eps=1e-5)
+
+
+def test_entmax_correct_multiple_alphas():
+    n = 4
+    x = torch.randn(n, 6, dtype=torch.float64, requires_grad=True)
+    alpha = 1.05 + torch.rand(n, dtype=torch.float64, requires_grad=True)
+
+    p1 = entmax_bisect(x, alpha)
+    p2_ = [entmax_bisect(x[i].unsqueeze(0), alpha[i].item()).squeeze()
+            for i in range(n)]
+    p2 = torch.stack(p2_)
+
+    assert torch.allclose(p1, p2)
+
+
+def test_entmax_grad_multiple_alphas():
+
+    for _ in range(10):
+        x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
+        alpha = 1.05 + torch.rand(4, dtype=torch.float64, requires_grad=True)
+        gradcheck(entmax_bisect, (x, alpha), eps=1e-5)
+

--- a/entmax/test_topk.py
+++ b/entmax/test_topk.py
@@ -15,16 +15,14 @@ from entmax.activations import (
 @pytest.mark.parametrize("Map", (Sparsemax, Entmax15))
 def test_mapping(dim, Map):
     f = Map(dim=dim, k=3)
-
-    for _ in range(10):
-        x = torch.randn(5, 6, 7, requires_grad=True, dtype=torch.float64)
-        gradcheck(f, (x,))
+    x = torch.randn(3, 4, 5, requires_grad=True, dtype=torch.float64)
+    gradcheck(f, (x,))
 
 
 @pytest.mark.parametrize("dim", (0, 1, 2))
 @pytest.mark.parametrize("coef", (0.00001, 0.5, 10000))
 def test_entmax_topk(dim, coef):
-    x = coef * torch.randn(10, 11, 12)
+    x = coef * torch.randn(3, 4, 5)
     tau1, supp1 = _entmax_threshold_and_support(x, dim=dim, k=None)
     tau2, supp2 = _entmax_threshold_and_support(x, dim=dim, k=5)
 
@@ -37,7 +35,7 @@ def test_entmax_topk(dim, coef):
 @pytest.mark.parametrize("k", (5, 30))
 def test_sparsemax_topk(dim, coef, k):
 
-    x = coef * torch.randn(10, 11, 12)
+    x = coef * torch.randn(3, 4, 5)
     tau1, supp1 = _sparsemax_threshold_and_support(x, dim=dim, k=None)
     tau2, supp2 = _sparsemax_threshold_and_support(x, dim=dim, k=k)
 


### PR DESCRIPTION
Added gradients wrt alpha in the EntmaxBisectFunction class and the wrapper entmax_bisect.
The extra computation is only performed if the alpha argument is a tensor with requires_grad=True.

Todos

 - [x] reference @goncalomcorreia's paper in readme
 - [ ] link to camera ready (when out)
 - [x] add a general extension to nd tensors and dim argument. I think this can be done inside entmax_bisect using views and unsqueeze. The requirement probably should be, if `X.shape = (m_1, m_2, ..., m_k)` and `dim=d` then `alpha.shape` must be `(m_1, ..., m_{d-1}, m_{d+1}, ..., m_k)`. (Weight sharing along certain dimensions can be achieved using `torch.expand` in user code)
 - [x] refactor losses
 - [x] add example for getting gradient wrt alpha in readme