### PR TITLE
ignore_index in loss functions

### DIFF
--- a/entmax/losses.py
+++ b/entmax/losses.py
@@ -7,8 +7,10 @@ from entmax.root_finding import entmax_bisect, sparsemax_bisect
 
 
 class _GenericLoss(nn.Module):
-    def __init__(self, ignore_index=-100, reduction="elementwise_mean"):
-        assert reduction in ["elementwise_mean", "sum", "none"]
+    def __init__(self, ignore_index=-100, reduction="mean"):
+        assert reduction in ["elementwise_mean", "sum", "none", "mean"]
+        if reduction == "elementwise_mean":
+            reduction = "mean"
         self.reduction = reduction
         self.ignore_index = ignore_index
         super(_GenericLoss, self).__init__()
@@ -28,7 +30,7 @@ class _GenericLoss(nn.Module):
             loss[valid_positions] = nonzero_loss
         if self.reduction == "sum":
             loss = loss.sum()
-        elif self.reduction == "elementwise_mean":
+        elif self.reduction == "mean":
             loss = loss.mean()
         return loss
 
@@ -257,7 +259,7 @@ class SparsemaxBisectLoss(_GenericLoss):
 
 
 class SparsemaxLoss(_GenericLoss):
-    def __init__(self, k=None, ignore_index=-100, reduction="elementwise_mean"):
+    def __init__(self, k=None, ignore_index=-100, reduction="mean"):
         self.k = k
         super(SparsemaxLoss, self).__init__(ignore_index, reduction)
 
@@ -271,7 +273,7 @@ class EntmaxBisectLoss(_GenericLoss):
         alpha=1.5,
         n_iter=50,
         ignore_index=-100,
-        reduction="elementwise_mean",
+        reduction="mean",
     ):
         self.alpha = alpha
         self.n_iter = n_iter
@@ -282,7 +284,7 @@ class EntmaxBisectLoss(_GenericLoss):
 
 
 class Entmax15Loss(_GenericLoss):
-    def __init__(self, k=100, ignore_index=-100, reduction="elementwise_mean"):
+    def __init__(self, k=100, ignore_index=-100, reduction="mean"):
         self.k = k
         super(Entmax15Loss, self).__init__(ignore_index, reduction)
 


### PR DESCRIPTION
This pull request implements two changes to make the loss function API closer to `nn.CrossEntropyLoss`.

* Treating `ignore_index`. The common use case is to use a pseudo class id such as -1 in the target tensor to indicate padding positions (or any samples that should be ignored in the loss computation). This PR filters out `ignore_index` from the target tensor before computing the actual loss; the current implementation does not do this.

* Adding reduction `mean` as a synonym to `elementwise_mean`. The latter has been deprecated in `nn.CrossEntropyLoss` in favor of `mean`.