### PR TITLE
Fix rare bug in activations.py

### DIFF
--- a/entmax/activations.py
+++ b/entmax/activations.py
@@ -160,7 +160,7 @@ class SparsemaxFunction(Function):
         grad_input = grad_output.clone()
         grad_input[output == 0] = 0
 
-        v_hat = grad_input.sum(dim=dim) / supp_size.to(output.dtype).squeeze()
+        v_hat = grad_input.sum(dim=dim) / supp_size.to(output.dtype).squeeze(dim)
         v_hat = v_hat.unsqueeze(dim)
         grad_input = torch.where(output != 0, grad_input - v_hat, grad_input)
         return grad_input, None, None


### PR DESCRIPTION
if the input to the sparsemax has dimensions with size=1, they are squeezed by accident in the backward pass, it seems.

e.g.
attn = torch.rand((64, 1, 6))
sparsemax(attn, dim=2)

in the backward pass, supp_size will be (64x1x1), and will be squeezed to (64) instead of (64x1), in line 163. This creates a weirdly shaped v_hat, but doesn't break the code immediately.

In the code I was running, this would only cause the code to break later on after a few training epochs (due to nans in gradients). After applying this change, the training seems stabler and doesn't break