### PR TITLE
Do not import entmax => torch in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: entmax.__version__

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 from distutils.core import setup
-from entmax import __version__
+
 
 setup(name='entmax',
-      version=__version__,
       url="https://github.com/deep-spin/entmax",
       author="Ben Peters, Goncalo M Correia, Vlad Niculae",
       author_email="vlad@vene.ro",


### PR DESCRIPTION
Currently `entmax/__init__.py` is imported during install, which imports `torch`. What this means is that if the user of this package, or *anything which depends upon it*, doesn't already have `torch` installed, the install will fail.

Following the advice from https://packaging.python.org/en/latest/guides/single-sourcing-package-version/#single-sourcing-the-package-version it looks like you can now get the same effect using `setup.cfg` and it will avoid actually executing the code but instead pull it from the AST.