### PR TITLE
Add support for automatic mixed precision

### DIFF
--- a/entmax/activations.py
+++ b/entmax/activations.py
@@ -13,6 +13,7 @@ See https://arxiv.org/pdf/1602.02068.
 import torch
 import torch.nn as nn
 from torch.autograd import Function
+from torch.cuda.amp import custom_fwd, custom_bwd
 
 
 def _make_ix_like(X, dim):
@@ -144,6 +145,7 @@ def _entmax_threshold_and_support(X, dim=-1, k=None):
 
 class SparsemaxFunction(Function):
     @classmethod
+    @custom_fwd(cast_inputs=torch.float32)
     def forward(cls, ctx, X, dim=-1, k=None):
         ctx.dim = dim
         max_val, _ = X.max(dim=dim, keepdim=True)
@@ -154,6 +156,7 @@ class SparsemaxFunction(Function):
         return output
 
     @classmethod
+    @custom_bwd
     def backward(cls, ctx, grad_output):
         supp_size, output = ctx.saved_tensors
         dim = ctx.dim
@@ -168,6 +171,7 @@ class SparsemaxFunction(Function):
 
 class Entmax15Function(Function):
     @classmethod
+    @custom_fwd(cast_inputs=torch.float32)
     def forward(cls, ctx, X, dim=0, k=None):
         ctx.dim = dim
 
@@ -182,6 +186,7 @@ class Entmax15Function(Function):
         return Y
 
     @classmethod
+    @custom_bwd
     def backward(cls, ctx, dY):
         Y, = ctx.saved_tensors
         gppr = Y.sqrt()  # = 1 / g'' (Y)

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -37,7 +37,7 @@ if torch.cuda.is_available():
             for _X in _Xs:
                 scores = func(_X, dim=-1)
                 prob_mass = scores.sum(-1)
-                assert torch.allclose(prob_mass, torch.tensor([1.0], device="cuda"))
+                assert torch.allclose(prob_mass, torch.tensor([1.0], dtype=dtype, device="cuda"))
 
     @pytest.mark.parametrize("Xs", (long_vecs, negatives))
     @pytest.mark.parametrize("func", mappings)
@@ -48,4 +48,4 @@ if torch.cuda.is_available():
         with torch.autocast(device_type="cuda", dtype=dtype):
             for _X, fpp in zip(_Xs, full_precision_probs):
                 probs = func(_X, dim=-1)
-                assert torch.allclose(probs, fpp)
+                assert torch.allclose(probs, fpp.to(dtype))

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -37,7 +37,7 @@ if torch.cuda.is_available():
             for _X in _Xs:
                 scores = func(_X, dim=-1)
                 prob_mass = scores.sum(-1)
-                assert torch.allclose(prob_mass, torch.tensor([1.0], dtype=dtype, device="cuda"))
+                assert torch.allclose(prob_mass, torch.tensor([1.0], dtype=prob_mass.dtype, device="cuda"))
 
     @pytest.mark.parametrize("Xs", (long_vecs, negatives))
     @pytest.mark.parametrize("func", mappings)
@@ -48,4 +48,4 @@ if torch.cuda.is_available():
         with torch.autocast(device_type="cuda", dtype=dtype):
             for _X, fpp in zip(_Xs, full_precision_probs):
                 probs = func(_X, dim=-1)
-                assert torch.allclose(probs, fpp.to(dtype))
+                assert torch.allclose(probs, fpp.to(probs.dtype))

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -32,6 +32,8 @@ if torch.cuda.is_available():
                 prob_mass = scores.sum(-1)
                 assert torch.allclose(prob_mass, torch.tensor([1.0], device="cuda"))
 
+    @pytest.mark.parametrize("func", mappings)
+    @pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
     def test_probs_close(func, dtype):
         full_precision_probs = [func(_X, dim=-1) for _X in Xs]
         _Xs = [_X.to(dtype) for _X in Xs]

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -26,6 +26,9 @@ if torch.cuda.is_available():
     @pytest.mark.parametrize("func", mappings)
     @pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
     def test_sum_one(func, dtype):
+        _Xs = [_X.to(dtype) for _X in Xs]
         with torch.autocast(device_type="cuda", dtype=dtype):
-            for X in Xs:
-                assert func(X).sum(-1).eq(1)
+            for _X in _Xs:
+                scores = func(_X)
+                prob_mass = scores.sum(-1)
+                assert torch.allclose(prob_mass, torch.tensor([1.0], device="cuda"))

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -23,8 +23,8 @@ if torch.cuda.is_available():
     ]
 
 
-    @pytest.mark.parameterize("func", mappings)
-    @pytest.mark.parameterize("dtype", (torch.bfloat16, torch.float16))
+    @pytest.mark.parametrize("func", mappings)
+    @pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
     def test_sum_one(func, dtype):
         with torch.autocast(device_type="cuda", dtype=dtype):
             for X in Xs:

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -5,47 +5,39 @@ from functools import partial
 from entmax import entmax15, sparsemax, entmax_bisect
 
 
-# These tests only work on cuda, so the first test will fail if you do not have it
-
-
-def test_cuda_available():
-    assert torch.cuda.is_available()
+def make_negatives(dtype, max_pow):
+    negatives = []
+    for i in range(2, max_pow + 1):
+        negative = torch.randn(128, dtype=dtype, device="cuda") - 10 ** i
+        negative[0] += 5
+        negatives.append(negative)
+    return negatives
 
 
 if torch.cuda.is_available():
 
     mappings = [entmax15, sparsemax, partial(entmax_bisect, alpha=1.5), partial(entmax_bisect, alpha=2)]
 
-    # make data
-    long_vecs = [
-        torch.randn(32000, dtype=torch.float32, device="cuda")
+    long_bf16 = [
+        torch.randn(32000, dtype=torch.bfloat16, device="cuda")
         for _ in range(5)
     ]
+    negatives_bf16 = make_negatives(torch.bfloat16, 5)
 
-    negatives = []
-    for i in range(2, 6):
-        negative = torch.randn(128, dtype=torch.float32, device="cuda") - 10 ** i
-        negative[0] += 5
-        negatives.append(negative)
+    long_fp16 = [
+        torch.randn(32000, dtype=torch.float16, device="cuda")
+        for _ in range(5)
+    ]
+    negatives_fp16 = make_negatives(torch.float16, 3)
 
-    @pytest.mark.parametrize("Xs", (long_vecs, negatives))
+    @pytest.mark.parametrize("Xs", (long_bf16, negatives_bf16, long_fp16, negatives_fp16))
     @pytest.mark.parametrize("func", mappings)
-    @pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
-    def test_sum_one(Xs, func, dtype):
-        _Xs = [X.to(dtype) for X in Xs]
-        with torch.autocast(device_type="cuda", dtype=dtype):
-            for _X in _Xs:
-                scores = func(_X, dim=-1)
-                prob_mass = scores.sum(-1)
-                assert torch.allclose(prob_mass, torch.tensor([1.0], dtype=prob_mass.dtype, device="cuda"))
+    def test_probs_close(Xs, func):
+        dtype = Xs[0].dtype
 
-    @pytest.mark.parametrize("Xs", (long_vecs, negatives))
-    @pytest.mark.parametrize("func", mappings)
-    @pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
-    def test_probs_close(Xs, func, dtype):
-        full_precision_probs = [func(X.to(dtype).to(torch.float32), dim=-1) for X in Xs]
+        full_precision_probs = [func(X.to(torch.float32), dim=-1) for X in Xs]
         _Xs = [X.to(dtype) for X in Xs]
         with torch.autocast(device_type="cuda", dtype=dtype):
             for _X, fpp in zip(_Xs, full_precision_probs):
                 probs = func(_X, dim=-1)
-                assert torch.allclose(probs, fpp.to(probs.dtype))
+                assert torch.allclose(probs, fpp.to(dtype))

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -17,26 +17,34 @@ if torch.cuda.is_available():
     mappings = [entmax15, sparsemax, partial(entmax_bisect, alpha=1.5), partial(entmax_bisect, alpha=2)]
 
     # make data
-    Xs = [
-        torch.randn(1000, dtype=torch.float32, device="cuda")
+    long_vecs = [
+        torch.randn(32000, dtype=torch.float32, device="cuda")
         for _ in range(5)
     ]
 
+    negatives = []
+    for i in range(2, 6):
+        negative = torch.randn(128, dtype=torch.float32, device="cuda") - 10 ** i
+        negative[0] += 5
+        negatives.append(negative)
+
+    @pytest.mark.parametrize("Xs", (long_vecs, negatives))
     @pytest.mark.parametrize("func", mappings)
     @pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
-    def test_sum_one(func, dtype):
-        _Xs = [_X.to(dtype) for _X in Xs]
+    def test_sum_one(Xs, func, dtype):
+        _Xs = [X.to(dtype) for X in Xs]
         with torch.autocast(device_type="cuda", dtype=dtype):
             for _X in _Xs:
                 scores = func(_X, dim=-1)
                 prob_mass = scores.sum(-1)
                 assert torch.allclose(prob_mass, torch.tensor([1.0], device="cuda"))
 
+    @pytest.mark.parametrize("Xs", (long_vecs, negatives))
     @pytest.mark.parametrize("func", mappings)
     @pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
-    def test_probs_close(func, dtype):
-        full_precision_probs = [func(_X.to(dtype).to(torch.float32), dim=-1) for _X in Xs]
-        _Xs = [_X.to(dtype) for _X in Xs]
+    def test_probs_close(Xs, func, dtype):
+        full_precision_probs = [func(X.to(dtype).to(torch.float32), dim=-1) for X in Xs]
+        _Xs = [X.to(dtype) for X in Xs]
         with torch.autocast(device_type="cuda", dtype=dtype):
             for _X, fpp in zip(_Xs, full_precision_probs):
                 probs = func(_X, dim=-1)

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -4,6 +4,7 @@ from functools import partial
 
 from entmax import entmax15, sparsemax, entmax_bisect
 
+torch.manual_seed(42)
 
 def make_negatives(dtype, max_pow):
     negatives = []
@@ -22,13 +23,13 @@ if torch.cuda.is_available():
         torch.randn(32000, dtype=torch.bfloat16, device="cuda")
         for _ in range(5)
     ]
-    negatives_bf16 = make_negatives(torch.bfloat16, 5)
+    negatives_bf16 = make_negatives(torch.bfloat16, 7)
 
     long_fp16 = [
         torch.randn(32000, dtype=torch.float16, device="cuda")
         for _ in range(5)
     ]
-    negatives_fp16 = make_negatives(torch.float16, 3)
+    negatives_fp16 = make_negatives(torch.float16, 4)
 
     @pytest.mark.parametrize("Xs", (long_bf16, negatives_bf16, long_fp16, negatives_fp16))
     @pytest.mark.parametrize("func", mappings)
@@ -40,4 +41,4 @@ if torch.cuda.is_available():
         with torch.autocast(device_type="cuda", dtype=dtype):
             for _X, fpp in zip(_Xs, full_precision_probs):
                 probs = func(_X, dim=-1)
-                assert torch.allclose(probs, fpp.to(dtype))
+                assert torch.allclose(probs, fpp)

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -38,6 +38,6 @@ if torch.cuda.is_available():
         full_precision_probs = [func(_X, dim=-1) for _X in Xs]
         _Xs = [_X.to(dtype) for _X in Xs]
         with torch.autocast(device_type="cuda", dtype=dtype):
-            for _X in _Xs:
+            for _X, fpp in zip(_Xs, full_precision_probs):
                 probs = func(_X, dim=-1)
-                assert torch.allclose(probs, full_precision_probs)
+                assert torch.allclose(probs, fpp)

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -1,0 +1,31 @@
+import pytest
+import torch
+from functools import partial
+
+from entmax import entmax15, sparsemax, entmax_bisect
+
+
+# These tests only work on cuda, so the first test will fail if you do not have it
+
+
+def test_cuda_available():
+    assert torch.cuda.is_available()
+
+
+if torch.cuda.is_available():
+
+    mappings = [entmax15, sparsemax, partial(entmax_bisect, alpha=1.5), partial(entmax_bisect, alpha=2)]
+
+    # make data
+    Xs = [
+        torch.randn(1000, dtype=torch.float32, device="cuda")
+        for _ in range(5)
+    ]
+
+
+    @pytest.mark.parameterize("func", mappings)
+    @pytest.mark.parameterize("dtype", (torch.bfloat16, torch.float16))
+    def test_sum_one(func, dtype):
+        with torch.autocast(device_type="cuda", dtype=dtype):
+            for X in Xs:
+                assert func(X).sum(-1).eq(1)

--- a/entmax/test_amp.py
+++ b/entmax/test_amp.py
@@ -35,7 +35,7 @@ if torch.cuda.is_available():
     @pytest.mark.parametrize("func", mappings)
     @pytest.mark.parametrize("dtype", (torch.bfloat16, torch.float16))
     def test_probs_close(func, dtype):
-        full_precision_probs = [func(_X, dim=-1) for _X in Xs]
+        full_precision_probs = [func(_X.to(dtype).to(torch.float32), dim=-1) for _X in Xs]
         _Xs = [_X.to(dtype) for _X in Xs]
         with torch.autocast(device_type="cuda", dtype=dtype):
             for _X, fpp in zip(_Xs, full_precision_probs):

--- a/entmax/test_losses.py
+++ b/entmax/test_losses.py
@@ -60,10 +60,3 @@ def test_index_ignored(Loss):
     loss_noignore = Loss(reduction="sum", ignore_index=-100)
 
     assert loss_ignore(x, y) < loss_noignore(x, y)
-
-
-if __name__ == "__main__":
-    test_sparsemax_loss()
-    test_entmax_loss()
-    test_sparsemax_bisect_loss()
-    test_entmax_bisect_loss()


### PR DESCRIPTION
This pull request adds decorators to `EntmaxBisectFunction`, `SparsemaxBisectFunction`, `Entmax15Function`, and `SparsemaxFunction` so that they will autocast to 32-precision if they occur inside an autocast context. This seems to be the right thing to do because bf16 and fp16 introduce numerical stability issues that cannot easily be solved. Upcasting should make it easy to incorporate entmax into any mixed-precision setting.

The actual code that needed to be written was incredibly simple; the vast majority of commits are me making silly mistakes while writing the tests.