### PR TITLE
Fix bug in entmax bisection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'ubuntu-20.04'
 
 strategy:
   matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'ubuntu-16.04'
+  vmImage: 'ubuntu-latest'
 
 strategy:
   matrix:

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -47,6 +47,7 @@ class EntmaxBisectFunction(Function):
         tau_lo = max_val - cls._gp(1, alpha)
         tau_hi = max_val - cls._gp(1 / d, alpha)
 
+        # Note: f_lo should always be non-negative.
         f_lo = cls._p(X - tau_lo, alpha).sum(dim) - 1
 
         dm = tau_hi - tau_lo
@@ -58,7 +59,7 @@ class EntmaxBisectFunction(Function):
             p_m = cls._p(X - tau_m, alpha)
             f_m = p_m.sum(dim) - 1
 
-            mask = (f_m * f_lo >= 0).unsqueeze(dim)
+            mask = (f_m >= 0).unsqueeze(dim)
             tau_lo = torch.where(mask, tau_m, tau_lo)
 
         if ensure_sum_one:


### PR DESCRIPTION
This PR fixes a bug in entmax bisection. When `f_lo=0` (which means `tau_lo` is the correct `tau`) the iterative search keeps increasing `tau_lo`and returns an incorrect tau very close to `tau_hi`. This is because the criterion for the branching in bisection was using `f_m * f_lo >= 0`, which returns True when `f_lo=0`. This problem happens rarely but it manifests when scores are peaked (leading to a one-hot solution) and mostly for large alpha. Here is a MWE with alpha=3:

```
import torch
from entmax import entmax_bisect
x = 1000*torch.randn(10, 100, dtype=torch.float32)
p = entmax_bisect(x, alpha=3, n_iter=100, ensure_sum_one=True)
print(p.max(1).values)
```

returns

```
tensor([1., 1., nan, nan, nan, nan, 1., nan, 1., nan])
```

(Even when `nan`s are not returned, an incorrect output may be produced which may be hard to notice when `ensure_sum_one=True`.)

The current fix uses the fact that `f_lo` should always be non-negative (since `tau_lo` is a lower bound to `tau`). Therefore the branching criterion can simply be replaced by `f_m >= 0`. 
