### PR TITLE
Implementation of normmax activation and loss and budget (k-subsets) activation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ generalizing softmax / cross-entropy.
   - A bisection-based algorithm for generic alpha-entmax.
   - Gradients w.r.t. alpha for adaptive, learned sparsity!
 
-*Requirements:* python 3, pytorch >= 1.0 (and pytest for unit tests)
+*Requirements:* python 3, pytorch >= 1.3 (and pytest for unit tests)
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Out[9]: tensor([0.0000, 0.4997, 0.5003])
 
 In [10]: budget_bisect(x, budget=2, dim=0)
 Out[10]: tensor([0.0000, 1.0000, 1.0000])
-
 ```
 
 Gradients w.r.t. alpha (continued):

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ generalizing softmax / cross-entropy.
   - Exact partial-sort algorithms for 1.5-entmax and 2-entmax (sparsemax).
   - A bisection-based algorithm for generic alpha-entmax.
   - Gradients w.r.t. alpha for adaptive, learned sparsity!
+  - Other sparse transformations: alpha-normmax and k-subsets budget (handled through bisection-based algorithms).
 
 *Requirements:* python 3, pytorch >= 1.0 (and pytest for unit tests)
 
@@ -26,7 +27,7 @@ In [1]: import torch
 
 In [2]: from torch.nn.functional import softmax
 
-In [2]: from entmax import sparsemax, entmax15, entmax_bisect
+In [2]: from entmax import sparsemax, entmax15, entmax_bisect, normmax_bisect, budget_bisect
 
 In [4]: x = torch.tensor([-2, 0, 0.5])
 
@@ -38,6 +39,15 @@ Out[6]: tensor([0.0000, 0.2500, 0.7500])
 
 In [7]: entmax15(x, dim=0)
 Out[7]: tensor([0.0000, 0.3260, 0.6740])
+
+In [8]: normmax_bisect(x, alpha=2, dim=0)
+Out[8]: tensor([0.0000, 0.3110, 0.6890])
+
+In [9]: normmax_bisect(x, alpha=1000, dim=0)
+Out[9]: tensor([0.0000, 0.4997, 0.5003])
+
+In [10]: budget_bisect(x, budget=2, dim=0)
+Out[10]: tensor([0.0000, 1.0000, 1.0000])
 
 ```
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,9 +14,9 @@ pool:
 
 strategy:
   matrix:
-    Python37Torch120:
+    Python37Torch130:
       python.version: '3.7'
-      pytorch.version: '1.2.0'
+      pytorch.version: '1.3.0'
 
     Python38Torch220:
       python.version: '3.8'

--- a/entmax/__init__.py
+++ b/entmax/__init__.py
@@ -1,19 +1,23 @@
-__version__ = "1.3.dev0"
+__version__ = "1.4.dev0"
 
 from entmax.activations import sparsemax, entmax15, Sparsemax, Entmax15
 from entmax.root_finding import (
     sparsemax_bisect,
     entmax_bisect,
+    normmax_bisect,
     SparsemaxBisect,
     EntmaxBisect,
+    NormmaxBisect
 )
 from entmax.losses import (
     sparsemax_loss,
     entmax15_loss,
     sparsemax_bisect_loss,
     entmax_bisect_loss,
+    normmax_bisect_loss,
     SparsemaxLoss,
     SparsemaxBisectLoss,
     Entmax15Loss,
     EntmaxBisectLoss,
+    NormmaxBisectLoss
 )

--- a/entmax/__init__.py
+++ b/entmax/__init__.py
@@ -5,9 +5,11 @@ from entmax.root_finding import (
     sparsemax_bisect,
     entmax_bisect,
     normmax_bisect,
+    budget_bisect,
     SparsemaxBisect,
     EntmaxBisect,
-    NormmaxBisect
+    NormmaxBisect,
+    BudgetBisect
 )
 from entmax.losses import (
     sparsemax_loss,

--- a/entmax/__init__.py
+++ b/entmax/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.dev0"
+__version__ = "1.3.dev0"
 
 from entmax.activations import sparsemax, entmax15, Sparsemax, Entmax15
 from entmax.root_finding import (

--- a/entmax/losses.py
+++ b/entmax/losses.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 from torch.autograd import Function
 
 from entmax.activations import sparsemax, entmax15
-from entmax.root_finding import entmax_bisect, sparsemax_bisect
+from entmax.root_finding import entmax_bisect, sparsemax_bisect, normmax_bisect
 
 
 class _GenericLoss(nn.Module):
@@ -128,6 +128,25 @@ class EntmaxBisectLossFunction(_GenericLossFunction):
         )
 
 
+class NormmaxBisectLossFunction(_GenericLossFunction):
+
+    n_fwd_args = 2
+
+    @classmethod
+    def project(cls, X, alpha, n_iter):
+        return normmax_bisect(X, alpha=alpha, n_iter=n_iter)
+
+    @classmethod
+    def omega(cls, p_star, alpha):
+        return 1 - (p_star ** alpha).sum(dim=1) ** (1 / alpha)
+
+    @classmethod
+    def forward(cls, ctx, X, target, alpha=2, n_iter=50):
+        return super().forward(
+            ctx, X, target, alpha, proj_args=dict(n_iter=n_iter)
+        )
+
+
 def sparsemax_loss(X, target, k=None):
     """sparsemax loss: sparse alternative to cross-entropy
 
@@ -241,6 +260,35 @@ def entmax_bisect_loss(X, target, alpha=1.5, n_iter=50):
     return EntmaxBisectLossFunction.apply(X, target, alpha, n_iter)
 
 
+def normmax_bisect_loss(X, target, alpha=2, n_iter=50):
+    """alpha-normmax loss: another sparse alternative to cross-entropy
+
+    Computed using bisection, supporting arbitrary alpha > 1.
+
+    Parameters
+    ----------
+    X : torch.Tensor, shape=(n_samples, n_classes)
+        The input 2D tensor of predicted scores
+
+    target : torch.LongTensor, shape=(n_samples,)
+        The ground truth labels, 0 <= target < n_classes.
+
+    alpha : float or torch.Tensor
+        Tensor of alpha parameters (> 1) to use for each row of X. If scalar
+        or python float, the same value is used for all rows. 
+
+    n_iter : int
+        Number of bisection iterations. For float32, 24 iterations should
+        suffice for machine precision.
+
+    Returns
+    -------
+    losses, torch.Tensor, shape=(n_samples,)
+        The loss incurred at each sample.
+    """
+    return NormmaxBisectLossFunction.apply(X, target, alpha, n_iter)
+
+
 class SparsemaxBisectLoss(_GenericLoss):
     def __init__(
         self, n_iter=50, ignore_index=-100, reduction="elementwise_mean"
@@ -275,6 +323,22 @@ class EntmaxBisectLoss(_GenericLoss):
 
     def loss(self, X, target):
         return entmax_bisect_loss(X, target, self.alpha, self.n_iter)
+
+
+class NormmaxBisectLoss(_GenericLoss):
+    def __init__(
+        self,
+        alpha=2,
+        n_iter=50,
+        ignore_index=-100,
+        reduction="elementwise_mean",
+    ):
+        self.alpha = alpha
+        self.n_iter = n_iter
+        super(NormmaxBisectLoss, self).__init__(ignore_index, reduction)
+
+    def loss(self, X, target):
+        return normmax_bisect_loss(X, target, self.alpha, self.n_iter)
 
 
 class Entmax15Loss(_GenericLoss):

--- a/entmax/losses.py
+++ b/entmax/losses.py
@@ -275,7 +275,7 @@ def normmax_bisect_loss(X, target, alpha=2, n_iter=50):
 
     alpha : float or torch.Tensor
         Tensor of alpha parameters (> 1) to use for each row of X. If scalar
-        or python float, the same value is used for all rows. 
+        or python float, the same value is used for all rows.
 
     n_iter : int
         Number of bisection iterations. For float32, 24 iterations should

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -49,7 +49,7 @@ class EntmaxBisectFunction(Function):
         tau_hi = max_val - cls._gp(1 / d, alpha)
 
         # Note: f_lo should always be non-negative.
-        f_lo = cls._p(X - tau_lo, alpha).sum(dim) - 1
+        # f_lo = cls._p(X - tau_lo, alpha).sum(dim) - 1
 
         dm = tau_hi - tau_lo
 
@@ -165,7 +165,7 @@ class NormmaxBisectFunction(Function):
         tau_lo = max_val - cls._gp(1, alpha)  # 1
         tau_hi = max_val - cls._gp(1 / d, alpha)  # (1/d)**(alpha-1)
 
-        f_lo = (cls._p(X - tau_lo, alpha) ** alpha).sum(dim) - 1
+        # f_lo = (cls._p(X - tau_lo, alpha) ** alpha).sum(dim) - 1
         dm = tau_hi - tau_lo
 
         for it in range(n_iter):
@@ -188,7 +188,7 @@ class NormmaxBisectFunction(Function):
 
         a = torch.where(Y > 0, Y, Y.new_zeros(1))
         b = torch.where(Y > 0, Y ** (2 - ctx.alpha), Y.new_zeros(1))
-        
+
         dX = dY * b
         q = dX.sum(ctx.dim).unsqueeze(ctx.dim)
         dX -= q * a
@@ -214,7 +214,6 @@ class BudgetBisectFunction(Function):
 
         ctx.budget = budget
         ctx.dim = dim
-        d = X.shape[dim]
 
         max_val, _ = X.max(dim=dim, keepdim=True)
         min_val, _ = X.min(dim=dim, keepdim=True)
@@ -224,8 +223,8 @@ class BudgetBisectFunction(Function):
         tau_lo = min_val - budget / X.shape[dim]
         tau_hi = max_val - budget / X.shape[dim]
 
-        f_lo = (torch.clamp(X - tau_lo, min=0, max=1).sum(dim).unsqueeze(dim)
-                - budget)
+        # f_lo = (torch.clamp(X - tau_lo, min=0, max=1).sum(dim).unsqueeze(dim)
+        #         - budget)
         dm = tau_hi - tau_lo
 
         for it in range(n_iter):

--- a/entmax/root_finding.py
+++ b/entmax/root_finding.py
@@ -3,8 +3,8 @@ Bisection implementation of alpha-entmax (Peters et al., 2019).
 Backward pass wrt alpha per (Correia et al., 2019). See
 https://arxiv.org/pdf/1905.05702 for detailed description.
 """
-# Author: Goncalo M Correia
-# Author: Ben Peters
+# Author: Goncalo M Correia <goncalommac@gmail.com>
+# Author: Ben Peters <benzurdopeters@gmail.com>
 # Author: Vlad Niculae <vlad@vene.ro>
 # Author: Andre Martins <andre.t.martins@gmail.com>
 

--- a/entmax/test_losses.py
+++ b/entmax/test_losses.py
@@ -8,6 +8,7 @@ from entmax.losses import (
     Entmax15Loss,
     SparsemaxBisectLoss,
     EntmaxBisectLoss,
+    NormmaxBisectLoss
 )
 
 
@@ -27,6 +28,7 @@ losses = [
     partial(Entmax15Loss, k=5),
     SparsemaxBisectLoss,
     EntmaxBisectLoss,
+    NormmaxBisectLoss
 ]
 
 
@@ -67,3 +69,4 @@ if __name__ == "__main__":
     test_entmax_loss()
     test_sparsemax_bisect_loss()
     test_entmax_bisect_loss()
+    test_normmax_bisect_loss()

--- a/entmax/test_root_finding.py
+++ b/entmax/test_root_finding.py
@@ -5,7 +5,7 @@ from functools import partial
 import torch
 from torch.autograd import gradcheck
 
-from entmax.root_finding import sparsemax_bisect, entmax_bisect
+from entmax.root_finding import sparsemax_bisect, entmax_bisect, normmax_bisect
 from entmax.activations import sparsemax, entmax15
 
 
@@ -42,6 +42,13 @@ def test_entmax_grad(alpha):
     gradcheck(entmax_bisect, (x, alpha), eps=1e-5)
 
 
+@pytest.mark.parametrize("alpha", (1.2, 1.5, 2, 5, 10))
+def test_normmax_grad(alpha):
+    alpha = torch.tensor(alpha, dtype=torch.float64)
+    x = .1 * torch.randn(1, 6, dtype=torch.float64, requires_grad=True)
+    gradcheck(normmax_bisect, (x, alpha), eps=1e-5)
+
+
 def test_entmax_correct_multiple_alphas():
     n = 4
     x = torch.randn(n, 6, dtype=torch.float64, requires_grad=True)
@@ -63,6 +70,13 @@ def test_entmax_grad_multiple_alphas():
     x = torch.randn(n, 6, dtype=torch.float64, requires_grad=True)
     alpha = 0.05 + 2.5*torch.rand((n, 1), dtype=torch.float64, requires_grad=True)
     gradcheck(entmax_bisect, (x, alpha), eps=1e-5)
+
+
+def test_normmax_grad_multiple_alphas():
+    n = 4
+    x = torch.randn(n, 6, dtype=torch.float64, requires_grad=True)
+    alpha = 1 + 2.5*torch.rand((n, 1), dtype=torch.float64)
+    gradcheck(normmax_bisect, (x, alpha), eps=1e-5)
 
 
 @pytest.mark.parametrize("dim", (0, 1, 2, 3))

--- a/entmax/test_root_finding.py
+++ b/entmax/test_root_finding.py
@@ -31,6 +31,34 @@ def test_entmax15():
     assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 
+def test_normmax():
+    x = torch.tensor([0, .25, .5, .75, 1], dtype=torch.float32)
+    p1 = normmax_bisect(x, alpha=2, dim=0)
+    p2 = torch.tensor([0.0000, 0.0239, 0.1746, 0.3254, 0.4761],
+                      dtype=torch.float32)
+    assert torch.sum((p1 - p2) ** 2) < 1e-7
+    p1 = normmax_bisect(x, alpha=1000, dim=0)
+    p2 = torch.tensor([0.0000, 0.0000, 0.3330, 0.3334, 0.3336],
+                      dtype=torch.float32)
+    assert torch.sum((p1 - p2) ** 2) < 1e-7
+
+
+def test_budget():
+    x = torch.tensor([0, .25, .5, .75, 1], dtype=torch.float32)
+    p1 = budget_bisect(x, budget=2, dim=0)
+    p2 = torch.tensor([0.0000, 0.1250, 0.3750, 0.6250, 0.8750],
+                      dtype=torch.float32)
+    assert torch.sum((p1 - p2) ** 2) < 1e-7
+    p1 = budget_bisect(2*x, budget=3, dim=0)
+    p2 = torch.tensor([0.0000, 0.2500, 0.7500, 1.0000, 1.0000],
+                      dtype=torch.float32)
+    assert torch.sum((p1 - p2) ** 2) < 1e-7
+    for c in (1, 2, 3, 4, 5):
+        p1 = budget_bisect(c*x, budget=1, dim=0)
+        p2 = sparsemax(c*x, dim=0)
+        assert torch.sum((p1 - p2) ** 2) < 1e-7
+
+
 def test_sparsemax_grad():
     x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
     gradcheck(sparsemax_bisect, (x,), eps=1e-5)

--- a/entmax/test_root_finding.py
+++ b/entmax/test_root_finding.py
@@ -45,7 +45,7 @@ def test_entmax_grad(alpha):
 @pytest.mark.parametrize("alpha", (1.2, 1.5, 2, 5, 10))
 def test_normmax_grad(alpha):
     alpha = torch.tensor(alpha, dtype=torch.float64)
-    x = .1 * torch.randn(1, 6, dtype=torch.float64, requires_grad=True)
+    x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
     gradcheck(normmax_bisect, (x, alpha), eps=1e-5)
 
 

--- a/entmax/test_root_finding.py
+++ b/entmax/test_root_finding.py
@@ -5,7 +5,8 @@ from functools import partial
 import torch
 from torch.autograd import gradcheck
 
-from entmax.root_finding import sparsemax_bisect, entmax_bisect, normmax_bisect
+from entmax.root_finding import (sparsemax_bisect, entmax_bisect,
+                                 normmax_bisect, budget_bisect)
 from entmax.activations import sparsemax, entmax15
 
 
@@ -49,6 +50,13 @@ def test_normmax_grad(alpha):
     gradcheck(normmax_bisect, (x, alpha), eps=1e-5)
 
 
+@pytest.mark.parametrize("k", (0, 1, 2, 3, 4, 5, 6))
+def test_budget_grad(k):
+    k = torch.tensor(k, dtype=torch.float64)
+    x = torch.randn(4, 6, dtype=torch.float64, requires_grad=True)
+    gradcheck(budget_bisect, (x, k), eps=1e-5)
+
+
 def test_entmax_correct_multiple_alphas():
     n = 4
     x = torch.randn(n, 6, dtype=torch.float64, requires_grad=True)
@@ -77,6 +85,13 @@ def test_normmax_grad_multiple_alphas():
     x = torch.randn(n, 6, dtype=torch.float64, requires_grad=True)
     alpha = 1 + 2.5*torch.rand((n, 1), dtype=torch.float64)
     gradcheck(normmax_bisect, (x, alpha), eps=1e-5)
+
+
+def test_budget_grad_multiple_k():
+    n = 4
+    x = torch.randn(n, 6, dtype=torch.float64, requires_grad=True)
+    k = 6*torch.rand((n, 1), dtype=torch.float64)
+    gradcheck(normmax_bisect, (x, k), eps=1e-5)
 
 
 @pytest.mark.parametrize("dim", (0, 1, 2, 3))

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='entmax',
                    "alternatives to softmax."),
       license="MIT",
       packages=['entmax'],
-      install_requires=['torch>=1.2'],
+      install_requires=['torch>=1.3'],
       python_requires=">=3.5")


### PR DESCRIPTION
This PR adds two sparse transformations to the entmax package:
- alpha-normmax (described in Blondel et al., 2020).  
- k-subsets budget: this returns a sparse vector which sums to k; when k=1 it recovers sparsemax.  

Bisection algorithms are implemented in both cases. For alpha-normmax, the corresponding Fenchel-Young loss is also implemented.

The activations and losses pass all the tests.