### PR TITLE
Enable returning support size with exact algorithms for alpha=1.5 and alpha=2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ generalizing softmax / cross-entropy.
   - Gradients w.r.t. alpha for adaptive, learned sparsity!
   - Other sparse transformations: alpha-normmax and k-subsets budget (handled through bisection-based algorithms).
 
-*Requirements:* python 3, pytorch >= 1.3 (and pytest for unit tests)
+*Requirements:* python 3, pytorch >= 1.9 (and pytest for unit tests)
 
 ## Example
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,9 +14,9 @@ pool:
 
 strategy:
   matrix:
-    Python37Torch130:
+    Python37Torch190:
       python.version: '3.7'
-      pytorch.version: '1.3.0'
+      pytorch.version: '1.9.0'
 
     Python38Torch220:
       python.version: '3.8'

--- a/bench/bench_return_support.py
+++ b/bench/bench_return_support.py
@@ -22,7 +22,7 @@ def main(args):
     # results["full"] = bench(None, num_threads, batch, n=args.n, ntimeit=20, logmin=-1.5, logmax=2)
 
     results["no_support"] = bench_topk(args.k, num_threads, batch, n=args.n, ntimeit=args.ntimeit, logmin=-1.5, logmax=2)
-    results["support"] = bench_topk(args.k, num_threads, batch, n=args.n, ntimeit=args.ntimeit, logmin=-1.5, logmax=2, return_support=True)
+    results["support"] = bench_topk(args.k, num_threads, batch, n=args.n, ntimeit=args.ntimeit, logmin=-1.5, logmax=2, return_support_size=True)
 
 
     for k, v in results.items():

--- a/bench/bench_topk.py
+++ b/bench/bench_topk.py
@@ -8,17 +8,17 @@ import torch.utils.benchmark as benchmark
 from entmax import entmax15
 
 
-def bench_topk(k, num_threads, batch, logmin=-3, logmax=3, n=20, ntimeit=10, return_support=False):
+def bench_topk(k, num_threads, batch, logmin=-3, logmax=3, n=20, ntimeit=10, return_support_size=False):
     supports = []
     runtimes = []
     for b in np.logspace(logmin, logmax, n):
         inp = batch * b
 
-        p, supp_raw = entmax15(inp, return_support=True, k=k)
+        p, supp_raw = entmax15(inp, return_support_size=True, k=k)
         supp = supp_raw.float().mean().cpu().item()
         print(b, supp, k)
-        if return_support:
-            stmt = 'entmax15(x, k=k, return_support=True)'
+        if return_support_size:
+            stmt = 'entmax15(x, k=k, return_support_size=True)'
         else:
             stmt = 'entmax15(x, k=k)'
         t0 = benchmark.Timer(

--- a/bench/bench_topk.py
+++ b/bench/bench_topk.py
@@ -1,0 +1,64 @@
+import argparse
+
+import numpy as np
+import matplotlib.pyplot as plt
+import torch
+import torch.utils.benchmark as benchmark
+
+from entmax import entmax15
+
+
+def bench(k, num_threads, batch, logmin=-3, logmax=3, n=20, ntimeit=10):
+    supports = []
+    runtimes = []
+    for b in np.logspace(logmin, logmax, n):
+        inp = batch * b
+
+        p, supp_raw = entmax15(inp, return_support=True, k=k)
+        supp = supp_raw.float().mean().cpu().item()
+        print(b, supp, k)
+        t0 = benchmark.Timer(
+            stmt='entmax15(x, k=k)',
+            setup='from __main__ import entmax15',
+            num_threads=num_threads,
+            globals={'x': inp, 'k': k}
+        )
+
+        supports.append(supp)
+        measurement = t0.timeit(ntimeit)
+        runtimes.append(measurement.mean)
+    return supports, runtimes
+
+
+# the question: does support size explain all the variance, or does entmax
+# also have high variance even with a consistent support size?
+def main(args):
+    # we want to understand how the runtime develops as a function of sparsity.
+    # do we want to think about the loss too?
+
+    num_threads = torch.get_num_threads()
+    device = torch.device("cuda:0") if args.gpu else torch.device("cpu")
+    batch = torch.randn(64, args.v, device=device)
+
+    results = dict()
+    for k in args.k:
+        results[k] = bench(k, num_threads, batch, n=100, ntimeit=5, logmin=-1.5, logmax=2)
+
+    # the action is all happening at the smaller support sizes. I should focus on them.
+
+    for k, v in results.items():
+        print(k)
+        plt.plot(v[0], v[1], label=k)
+    plt.xticks(args.k)
+    plt.legend()
+    plt.savefig(args.out, format="pdf", bbox_inches="tight", dpi=2000)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--v", type=int, default=32000)
+    parser.add_argument("--k", nargs="+", type=int)
+    parser.add_argument("--gpu", action="store_true")
+    parser.add_argument("--out", default="fig.pdf")
+    args = parser.parse_args()
+    main(args)

--- a/bench/bench_topk.py
+++ b/bench/bench_topk.py
@@ -38,11 +38,12 @@ def main(args):
 
     num_threads = torch.get_num_threads()
     device = torch.device("cuda:0") if args.gpu else torch.device("cpu")
-    batch = torch.randn(64, args.v, device=device)
+    batch = torch.randn(args.batch, args.v, device=device)
 
     results = dict()
+    # results["full"] = bench(None, num_threads, batch, n=args.n, ntimeit=20, logmin=-1.5, logmax=2)
     for k in args.k:
-        results[k] = bench(k, num_threads, batch, n=100, ntimeit=5, logmin=-1.5, logmax=2)
+        results[k] = bench(k, num_threads, batch, n=args.n, ntimeit=args.ntimeit, logmin=-1.5, logmax=2)
 
     # the action is all happening at the smaller support sizes. I should focus on them.
 
@@ -56,6 +57,9 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=128)
+    parser.add_argument("--n", type=int, default=100)
+    parser.add_argument("--ntimeit", type=int, default=20)
     parser.add_argument("--v", type=int, default=32000)
     parser.add_argument("--k", nargs="+", type=int)
     parser.add_argument("--gpu", action="store_true")

--- a/entmax/activations.py
+++ b/entmax/activations.py
@@ -192,7 +192,7 @@ class Entmax15Function(Function):
         return dX, None, None, None
 
 
-def sparsemax(X, dim=-1, k=None, return_support=False):
+def sparsemax(X, dim=-1, k=None, return_support_size=False):
     """sparsemax: normalizing sparse transform (a la softmax).
 
     Solves the projection:
@@ -214,7 +214,7 @@ def sparsemax(X, dim=-1, k=None, return_support=False):
         this function is recursively called with a 2*k schedule.
         If `None`, full sorting is performed from the beginning.
 
-    return_support : bool
+    return_support_size : bool
         Whether to return the support size of the result as well as the result
         itself.
 
@@ -226,12 +226,12 @@ def sparsemax(X, dim=-1, k=None, return_support=False):
               where it is 1.
     """
     P, support = SparsemaxFunction.apply(X, dim, k)
-    if return_support:
+    if return_support_size:
         return P, support
     return P
 
 
-def entmax15(X, dim=-1, k=None, return_support=False):
+def entmax15(X, dim=-1, k=None, return_support_size=False):
     """1.5-entmax: normalizing sparse transform (a la softmax).
 
     Solves the optimization problem:
@@ -255,7 +255,7 @@ def entmax15(X, dim=-1, k=None, return_support=False):
         this function is recursively called with a 2*k schedule.
         If `None`, full sorting is performed from the beginning.
 
-    return_support : bool
+    return_support_size : bool
         Whether to return the support size of the result as well as the result
         itself.
 
@@ -268,13 +268,13 @@ def entmax15(X, dim=-1, k=None, return_support=False):
     """
 
     P, support = Entmax15Function.apply(X, dim, k)
-    if return_support:
+    if return_support_size:
         return P, support
     return P
 
 
 class Sparsemax(nn.Module):
-    def __init__(self, dim=-1, k=None, return_support=False):
+    def __init__(self, dim=-1, k=None, return_support_size=False):
         """sparsemax: normalizing sparse transform (a la softmax).
 
         Solves the projection:
@@ -293,21 +293,21 @@ class Sparsemax(nn.Module):
             this function is recursively called with a 2*k schedule.
             If `None`, full sorting is performed from the beginning.
 
-        return_support : bool
+        return_support_size : bool
             Whether to return the support size of the result as well as the
             result itself.
         """
         self.dim = dim
         self.k = k
-        self.return_support = return_support
+        self.return_support_size = return_support_size
         super(Sparsemax, self).__init__()
 
     def forward(self, X):
-        return sparsemax(X, dim=self.dim, k=self.k, return_support=self.return_support)
+        return sparsemax(X, dim=self.dim, k=self.k, return_support_size=self.return_support_size)
 
 
 class Entmax15(nn.Module):
-    def __init__(self, dim=-1, k=None, return_support=False):
+    def __init__(self, dim=-1, k=None, return_support_size=False):
         """1.5-entmax: normalizing sparse transform (a la softmax).
 
         Solves the optimization problem:
@@ -328,14 +328,14 @@ class Entmax15(nn.Module):
             this function is recursively called with a 2*k schedule.
             If `None`, full sorting is performed from the beginning.
 
-        return_support : bool
+        return_support_size : bool
             Whether to return the support size of the result as well as the
             result itself.
         """
         self.dim = dim
         self.k = k
-        self.return_support = return_support
+        self.return_support_size = return_support_size
         super(Entmax15, self).__init__()
 
     def forward(self, X):
-        return entmax15(X, dim=self.dim, k=self.k, return_support=self.return_support)
+        return entmax15(X, dim=self.dim, k=self.k, return_support_size=self.return_support_size)

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='entmax',
                    "alternatives to softmax."),
       license="MIT",
       packages=['entmax'],
-      install_requires=['torch>=1.3'],
+      install_requires=['torch>=1.9'],
       python_requires=">=3.5")


### PR DESCRIPTION
This pull request enables the support size (the number of nonzero elements in the probability vector predicted by entmax) to be returned as a second output from `entmax.entmax15`, `entmax.sparsemax`, and their respective loss functions. This is fast because the support sizes are already computed inside the exact algorithm, it's just a question of exposing them to the user. This pull request does NOT implement returning support for `entmax_bisect` because the bisection-based algorithm does not explicitly compute the support size, so it cannot be returned for free.

The main application of this feature is for logging and benchmarking. The accompanying benchmarking scripts show how strongly the runtime of the topk algorithm depends on the support size.

```
In [1]: z = torch.tensor([5, 5, 0])

In [2]: entmax15(z)
Out[2]: tensor([0.5000, 0.5000, 0.0000])

In [3]: entmax15(z, return_support=True)
Out[3]: (tensor([0.5000, 0.5000, 0.0000]), tensor([2]))

```